### PR TITLE
plat-3142 Exported dora metrics dashboard as a back up

### DIFF
--- a/dashboards/DORA Metrics Dashboard.json
+++ b/dashboards/DORA Metrics Dashboard.json
@@ -1,0 +1,642 @@
+ {
+  "metadata": {
+    "configurationVersions": [
+      7
+    ],
+    "clusterVersion": "1.279.145.20231122-074223"
+  },
+  "id": "bd8af045-d417-4ea5-b330-88ee6817fbaf",
+  "dashboardMetadata": {
+    "name": "DORA Metrics Dashboard",
+    "shared": true,
+    "owner": "nicola.cassidy@digital.cabinet-office.gov.uk",
+    "popularity": 3,
+    "hasConsistentColors": false
+  },
+  "tiles": [
+    {
+      "name": "Lead time for Change",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 76,
+        "left": 38,
+        "width": 1102,
+        "height": 456
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "devplatform.sam-pipelines.deployment.time.test",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "environment"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "nestedFilters": [],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(devplatform.sam-pipelines.deployment.time.test:splitBy(environment):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 76,
+        "left": 1444,
+        "width": 304,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Lead time for change\n\nThis metric looks at time from a merge to main from the metadata of zip file to successful AWS CodeBuild deploy to prod."
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 532,
+        "left": 1444,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Deployment frequency\n\nThis metric looks at the number of deployments to prod in a 7 day period. \n\nIt is split by pipeline."
+    },
+    {
+      "name": "DORA Metrics",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 38,
+        "width": 570,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1026,
+        "left": 1444,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Change Failure Rate\n\nThis metric measures the percentage of deployments that result in a failure in production.\n\nAccording to DORA Metrics:\n\n**Elite - 0-15%**\n\n**High - 0-15%**\n\n**Medium - 0-15%**\n\n**Low - 46-60%**"
+    },
+    {
+      "name": "Deployment Frequency over last 7 days",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 532,
+        "left": 38,
+        "width": 1102,
+        "height": 494
+      },
+      "tileFilter": {
+        "timeframe": "-7d to now"
+      },
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "dt.entity.custom_device"
+          ],
+          "metricSelector": "ext:cloud.aws.codebuild.buildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-76285BB70D027EE1\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-37C51857B6DDB696\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-A671E18C70697687\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-5B946612B27C46D9\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-42B0326AF2C986A0\")):splitBy(\"dt.entity.custom_device\"):sort(value(auto,descending)):limit(100)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Builds Sum",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "A:dt.entity.custom_device.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(ext:cloud.aws.codebuild.buildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-76285BB70D027EE1)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-37C51857B6DDB696)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-A671E18C70697687)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-5B946612B27C46D9)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-42B0326AF2C986A0)):splitBy(\"dt.entity.custom_device\"):sort(value(auto,descending)):limit(100)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Deployment Frequency",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 532,
+        "left": 1140,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {
+        "timeframe": "-7d to now"
+      },
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "ext:cloud.aws.codebuild.buildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-76285BB70D027EE1\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-37C51857B6DDB696\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-A671E18C70697687\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-5B946612B27C46D9\")):filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-42B0326AF2C986A0\")):splitBy():count:sort(value(auto,descending)):limit(100)/7",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(ext:cloud.aws.codebuild.buildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-76285BB70D027EE1)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-37C51857B6DDB696)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-A671E18C70697687)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-5B946612B27C46D9)):filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-42B0326AF2C986A0)):splitBy():count:sort(value(auto,descending)):limit(100)/7):limit(100):names"
+      ]
+    },
+    {
+      "name": "Change Failure rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1026,
+        "left": 38,
+        "width": 1102,
+        "height": 494
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "ext:cloud.aws.codebuild.succeededBuildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):splitBy():sort(value(auto,descending)):limit(100)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "ext:cloud.aws.codebuild.failedBuildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):splitBy():sort(value(auto,descending)):limit(100)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "ext:cloud.aws.codebuild.failedBuildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):splitBy():sort(value(auto,descending)):limit(100)/ext:cloud.aws.codebuild.succeededBuildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):splitBy():sort(value(auto,descending)):limit(100)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "TURQUOISE",
+              "seriesType": "LINE",
+              "alias": "Change Failure Rate"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            },
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "RIGHT",
+              "queryIds": [
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(ext:cloud.aws.codebuild.succeededBuildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):splitBy():sort(value(auto,descending)):limit(100)):limit(100):names,(ext:cloud.aws.codebuild.failedBuildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):splitBy():sort(value(auto,descending)):limit(100)):limit(100):names,(ext:cloud.aws.codebuild.failedBuildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):splitBy():sort(value(auto,descending)):limit(100)/ext:cloud.aws.codebuild.succeededBuildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):splitBy():sort(value(auto,descending)):limit(100)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Change failure rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1026,
+        "left": 1140,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "ext:cloud.aws.codebuild.buildsSum:splitBy():sort(value(auto,descending)):limit(100)",
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "ext:cloud.aws.codebuild.failedBuildsSum:splitBy():sort(value(auto,descending)):limit(100)",
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "ext:cloud.aws.codebuild.failedBuildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):splitBy():sort(value(auto,descending)):limit(100)/ext:cloud.aws.codebuild.succeededBuildsSum:filter(ne(\"dt.entity.custom_device\",\"CUSTOM_DEVICE-26F7BD3CF246B058\")):splitBy():sort(value(auto,descending)):limit(100)*100",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "%",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(ext:cloud.aws.codebuild.failedBuildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):splitBy():sort(value(auto,descending)):limit(100)/ext:cloud.aws.codebuild.succeededBuildsSum:filter(ne(\"dt.entity.custom_device\",CUSTOM_DEVICE-26F7BD3CF246B058)):splitBy():sort(value(auto,descending)):limit(100)*100):limit(100):names"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
PLAT-3142

Exported DORA dashboard from dynatrace as a back up json file.

Deployment Frequency:
<img width="775" alt="Screenshot 2023-11-30 at 17 34 10" src="https://github.com/govuk-one-login/observability-configuration/assets/130485869/151c0be5-5a3f-45ba-897f-f35a52fd994f">

<img width="798" alt="Screenshot 2023-11-30 at 17 34 24" src="https://github.com/govuk-one-login/observability-configuration/assets/130485869/013facd4-9be3-4f2e-b313-851d35d23f3c">

<img width="800" alt="Screenshot 2023-11-30 at 17 36 26" src="https://github.com/govuk-one-login/observability-configuration/assets/130485869/b7a886fa-4464-4f64-bd73-ecd014a23b1c">

Change Failure Rate:
<img width="789" alt="Screenshot 2023-11-30 at 17 37 58" src="https://github.com/govuk-one-login/observability-configuration/assets/130485869/328be447-01b5-4cd4-886e-1e5a428b0fc8">

<img width="796" alt="Screenshot 2023-11-30 at 17 38 12" src="https://github.com/govuk-one-login/observability-configuration/assets/130485869/a6c438f3-2865-449a-90c1-ac7f8704a90e">

<img width="793" alt="Screenshot 2023-11-30 at 17 38 40" src="https://github.com/govuk-one-login/observability-configuration/assets/130485869/000d3019-fabe-44a3-a9e4-879c386cf3aa">

Lead Time for Change:
<img width="1104" alt="Screenshot 2023-11-30 at 17 40 00" src="https://github.com/govuk-one-login/observability-configuration/assets/130485869/ae6bd55b-3842-4423-9a4c-1c1ca949199e">


