### PR TITLE
Change to referencing the alerting profile

### DIFF
--- a/problem_notifications.tf
+++ b/problem_notifications.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_slack_notification" "slack_notification" {
   active  = true
   name    = "di-slack-notification"
-  profile = "di-alerting-profile"
+  profile = dynatrace_alerting.di-alerting-profile.id
   url     = local.is_production ? jsondecode(data.aws_secretsmanager_secret_version.pr.secret_string)["SLACK_URL"] : jsondecode(data.aws_secretsmanager_secret_version.np.secret_string)["SLACK_URL"]
   channel = local.is_production ? jsondecode(data.aws_secretsmanager_secret_version.pr.secret_string)["SLACK_CHANNEL"] : jsondecode(data.aws_secretsmanager_secret_version.np.secret_string)["SLACK_CHANNEL"]
   message = "{State} {ProblemSeverity} Problem {ProblemID}: {ImpactedEntity}"


### PR DESCRIPTION
# Description:
The alerting profile reference should be the ID of the resource, not free text

## Ticket number:
[OBS-199]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[OBS-199]: https://govukverify.atlassian.net/browse/OBS-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ