### PR TITLE
Add dimension filter to each AWS account MZ, filtering for aws.account.id

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -22,3 +22,25 @@ provider "registry.terraform.io/dynatrace-oss/dynatrace" {
     "zh:e884adc31eb0a05048db8b480292bbe69ae8e0ea837966a6ad3d1bbc53ffc941",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.34.0"
+  hashes = [
+    "h1:1Y1JgV1z99QqAK06+atyfNqreZxyGZKbm4mZO4VhhT8=",
+    "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
+    "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
+    "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
+    "zh:6021b905d9b3cd3d7892eb04d405c6fa20112718de1d6ef7b9f1db0b0c97721a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e61b8e0ccf923979cd2dc1f1140dbcb02f92248578e10c1996f560b6306317c",
+    "zh:ad6bf62cdcf531f2f92f6416822918b7ba2af298e4a0065c6baf44991fda982d",
+    "zh:b698b041ef38837753bbe5265dddbc70b76e8b8b34c5c10876e6aab0eb5eaf63",
+    "zh:bb799843c534f6a3f072a99d93a3b53ff97c58a96742be15518adf8127706784",
+    "zh:cebee0d942c37cd3b21e9050457cceb26d0a6ea886b855dab64bb67d78f863d1",
+    "zh:e061fdd1cb99e7c81fb4485b41ae000c6792d38f73f9f50aed0d3d5c2ce6dcfb",
+    "zh:eeb4943f82734946362696928336357cd1d36164907ae5905da0316a67e275e1",
+    "zh:ef09b6ad475efa9300327a30cbbe4373d817261c8e41e5b7391750b16ef4547d",
+    "zh:f01aab3881cd90b3f56da7c2a75f83da37fd03cc615fc5600a44056a7e0f9af7",
+    "zh:fcd0f724ebc4b56a499eb6c0fc602de609af18a0d578befa2f7a8df155c55550",
+  ]
+}

--- a/mzs.tf
+++ b/mzs.tf
@@ -156,5 +156,22 @@ resource "dynatrace_management_zone_v2" "all" {
       enabled         = true
       entity_selector = "type(SERVICE),fromRelationships.runsOn(type(AWS_LAMBDA_FUNCTION),fromRelationships.isAccessibleBy(type(AWS_CREDENTIALS),awsAccountId(${each.value.id})))"
     }
+
+    rule {
+      type    = "DIMENSION"
+      enabled = true
+      dimension_rule {
+        applies_to = "METRIC"
+
+        dimension_conditions {
+          condition {
+            condition_type = "DIMENSION"
+            rule_matcher   = "EQUALS"
+            key            = "aws.account.id"
+            value          = each.value.id
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description:
Adds a filter to each MZ to filter metrics with a dimension of `aws.account.id`, so those metrics will appear in the MZ view in Data Explorer.

## Ticket number:
[OBS-242]


[OBS-242]: https://govukverify.atlassian.net/browse/OBS-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ