### PR TITLE
[QA-417] Strip dashboard ID and add pre-merge check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,27 @@ env:
   TF_VAR_synthetic_requests_cost: ${{ secrets.synthetic_requests_cost }}
 
 jobs:
+  Check_DashboardFormat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Check dashboard IDs not present
+        run: |
+          for file in dashboards/*.json dashboards/**/*.json; do
+            echo "Checking ${file}"
+            ID=$(jq '.id' < $file)
+            if [ "$ID" != null  ]
+            then
+              echo "Error: ${file} contains '.id' (${ID}) "
+              exit 1
+            fi
+          done
   Check_NonProd:
     env:
       DYNATRACE_API_TOKEN: ${{ secrets.NONPROD_DYNATRACE_API_TOKEN}}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,9 +31,8 @@ jobs:
           for file in dashboards/*.json dashboards/**/*.json; do
             echo "Checking ${file}"
             ID=$(jq '.id' < $file)
-            if [ "$ID" != null  ]
-            then
-              echo "Error: ${file} contains '.id' (${ID}) "
+            if [ "$ID" != null ]; then
+              echo "Error: ${file} contains '.id' (${ID})"
               exit 1
             fi
           done

--- a/dashboards/aws_service_quotas.json
+++ b/dashboards/aws_service_quotas.json
@@ -1,11 +1,4 @@
 {
-  "metadata": {
-    "configurationVersions": [
-      1
-    ],
-    "clusterVersion": "1.285.108.20240223-195257"
-  },
-  "id": "812352c3-752a-42ba-8a3d-9d4dda9f4cc4",
   "dashboardMetadata": {
     "name": "AWS Service Quotas",
     "shared": true,


### PR DESCRIPTION
# Description:
Removing the ID and metadata from the `aws_service_quotas.json` dashboard added in #61, which is causing [terraform apply](https://github.com/govuk-one-login/observability-configuration/actions/runs/8186441487) to fail.

Also add a job to the pre-merge checks to confirm that no dashboard JSON definitions contain an ID, to prevent similar failures on merge.

Check action tested:
- [Expected failure](https://github.com/govuk-one-login/observability-configuration/actions/runs/8187341935)
- [Expected success](https://github.com/govuk-one-login/observability-configuration/actions/runs/8187358849)

## Ticket number:
[QA-417]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[QA-417]: https://govukverify.atlassian.net/browse/QA-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ