### PR TITLE
[QA-467] Update metric sources for AWS Service Quota dashboard

### DIFF
--- a/dashboards/aws_service_quotas.json
+++ b/dashboards/aws_service_quotas.json
@@ -29,7 +29,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"CryptographicOperationsSymmetric\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsSymmetric\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -109,7 +109,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsSymmetric)):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -134,7 +134,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"CryptographicOperationsRsa\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsRsa\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -214,7 +214,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsRsa)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsRsa)):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -239,7 +239,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"CryptographicOperationsEcc\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsEcc\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -319,7 +319,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsEcc)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsEcc)):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -343,7 +343,7 @@
           "splitBy": [
             "dt.entity.custom_device"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(\"Resource\",\"DescribeSecret\"),eq(\"Resource\",\"GetSecretValue\"))):splitBy(\"dt.entity.custom_device\"):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeSecret\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -423,7 +423,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(Resource,DescribeSecret),eq(Resource,GetSecretValue))):splitBy(\"dt.entity.custom_device\"):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",DescribeSecret),eq(\"resource\",GetSecretValue))):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -448,7 +448,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"ListSecrets\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"ListSecrets\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -528,7 +528,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,ListSecrets)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",ListSecrets)):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -543,7 +543,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## AWS Service Quota Dashboard\n\nThis dashboard provides an overview of AWS API usage metrics against the default [Service Quotas](https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html)\n\nTo use this dashboard, select an AWS environment from the management zone filter `⧩` in the top right of the dashboard\n\nAll metrics are generated by CloudWatch and available in Dynatrace under the '`ext:cloud.aws.usage.callCountSumByClassResourceType`' metric"
+      "markdown": "## AWS Service Quota Dashboard\n\nThis dashboard provides an overview of AWS API usage metrics against the default [Service Quotas](https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html)\n\nTo use this dashboard, select an AWS environment from the management zone filter `⧩` in the top right of the dashboard\n\nAll metrics are generated by CloudWatch and available in Dynatrace under the '`cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType`' metric"
     },
     {
       "name": "Markdown",
@@ -595,7 +595,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"CryptographicOperationsEcc\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s)/300)*100):setUnit(Percent)",
+          "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsEcc\")):splitBy(\"aws.account.id\"):sum:rate(1s)/300)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
         }
@@ -668,8 +668,8 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsEcc)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/300)*100):setUnit(Percent)):limit(100):names:fold(max)",
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsEcc)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/300)*100):setUnit(Percent))"
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsEcc)):splitBy(\"aws.account.id\"):sum:rate(1s)/300)*100):setUnit(Percent)):limit(100):names:fold(max)",
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsEcc)):splitBy(\"aws.account.id\"):sum:rate(1s)/300)*100):setUnit(Percent))"
       ]
     },
     {
@@ -694,7 +694,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"CryptographicOperationsRsa\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s)/500)*100):setUnit(Percent)",
+          "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsRsa\")):splitBy(\"aws.account.id\"):sum:rate(1s)/500)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
         }
@@ -767,8 +767,8 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsRsa)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/500)*100):setUnit(Percent)):limit(100):names:fold(max)",
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsRsa)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/500)*100):setUnit(Percent))"
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsRsa)):splitBy(\"aws.account.id\"):sum:rate(1s)/500)*100):setUnit(Percent)):limit(100):names:fold(max)",
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsRsa)):splitBy(\"aws.account.id\"):sum:rate(1s)/500)*100):setUnit(Percent))"
       ]
     },
     {
@@ -793,7 +793,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"CryptographicOperationsSymmetric\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s)/10000)*100):setUnit(Percent)",
+          "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsSymmetric\")):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
         }
@@ -866,8 +866,8 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):limit(100):names:fold(max)",
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent))"
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsSymmetric)):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent)):limit(100):names:fold(max)",
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",CryptographicOperationsSymmetric)):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent))"
       ]
     },
     {
@@ -892,7 +892,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(\"Resource\",\"DescribeSecret\"),eq(\"Resource\",\"GetSecretValue\"))):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s)/10000)*100):setUnit(Percent)",
+          "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeSecret\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
         }
@@ -965,8 +965,8 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(Resource,DescribeSecret),eq(Resource,GetSecretValue))):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):limit(100):names:fold(max)",
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(Resource,DescribeSecret),eq(Resource,GetSecretValue))):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent))"
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",DescribeSecret),eq(\"resource\",GetSecretValue))):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent)):limit(100):names:fold(max)",
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",DescribeSecret),eq(\"resource\",GetSecretValue))):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent))"
       ]
     },
     {
@@ -991,7 +991,7 @@
             "dt.entity.custom_device",
             "Resource"
           ],
-          "metricSelector": "((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(\"Resource\",\"ListSecrets\")):splitBy(\"dt.entity.custom_device\", \"Resource\"):rate(1s)/100)*100):setUnit(Percent)",
+          "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"ListSecrets\")):splitBy(\"aws.account.id\"):sum:rate(1s)/100)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
         }
@@ -1064,8 +1064,8 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,ListSecrets)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/100)*100):setUnit(Percent)):limit(100):names:fold(max)",
-        "resolution=null&(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,ListSecrets)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/100)*100):setUnit(Percent))"
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",ListSecrets)):splitBy(\"aws.account.id\"):sum:rate(1s)/100)*100):setUnit(Percent)):limit(100):names:fold(max)",
+        "resolution=null&(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",ListSecrets)):splitBy(\"aws.account.id\"):sum:rate(1s)/100)*100):setUnit(Percent))"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
Updating metric sources and queries to use the metric stream metrics as the source

```diff
- ext:cloud.aws.usage.callCountSumByClassResourceType
+ cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType
```

## Ticket number:
QA-467

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
