### PR TITLE
OLH-1698: Add browser monitor for webchat widget

### DIFF
--- a/modules/monitors/webchat/monitor.tf
+++ b/modules/monitors/webchat/monitor.tf
@@ -1,0 +1,86 @@
+resource "dynatrace_browser_monitor" "monitor" {
+  name      = "${var.domain_name} - Check webchat loads"
+  enabled   = var.enabled
+  frequency = var.frequency
+  locations = [
+    for l in data.dynatrace_synthetic_locations.locations.locations : l.entity_id
+    if l.cloud_platform == "AMAZON_EC2"
+  ]
+  anomaly_detection {
+    loading_time_thresholds {
+      enabled = true
+    }
+    outage_handling {
+      global_outage  = true
+      retry_on_error = false
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  key_performance_metrics {
+    load_action_kpm = "VISUALLY_COMPLETE"
+    xhr_action_kpm  = "VISUALLY_COMPLETE"
+  }
+  script {
+    type = "clickpath"
+    configuration {
+      device {
+        name        = "Desktop"
+        orientation = "landscape"
+      }
+    }
+    events {
+      event {
+        description = "Loading English contact page"
+        navigate {
+          url = "https://${var.domain_name}/contact-gov-uk-one-login?lng=en"
+          wait {
+            wait_for = "validation"
+            timeout  = 10000
+            validation {
+              type          = "element_match"
+              fail_if_found = false
+              target {
+                locators {
+                  locator {
+                    type  = "css"
+                    value = "button.sa-chat-tab"
+                  }
+
+                }
+              }
+            }
+          }
+        }
+      }
+      event {
+        description = "Loading Welsh contact page"
+        navigate {
+          url = "https://${var.domain_name}/contact-gov-uk-one-login?lng=cy"
+          wait {
+            wait_for = "validation"
+            timeout  = 10000
+            validation {
+              type          = "element_match"
+              fail_if_found = false
+              target {
+                locators {
+                  locator {
+                    type  = "css"
+                    value = "button.sa-chat-tab"
+                  }
+
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+data "dynatrace_synthetic_locations" "locations" {
+  name = "London"
+}

--- a/modules/monitors/webchat/site.tf
+++ b/modules/monitors/webchat/site.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    dynatrace = {
+      source  = "dynatrace-oss/dynatrace"
+      version = "1.49.1"
+    }
+  }
+}

--- a/modules/monitors/webchat/variables.tf
+++ b/modules/monitors/webchat/variables.tf
@@ -1,0 +1,11 @@
+variable "domain_name" {
+  default = "home.account.gov.uk"
+}
+
+variable "enabled" {
+  default = false
+}
+
+variable "frequency" {
+  default = 60
+}

--- a/monitors.tf
+++ b/monitors.tf
@@ -20,3 +20,11 @@ module "signin-browser-monitor" {
   environment              = var.environment == "production" ? "production" : "integration"
   use_basic_authentication = var.environment != "production"
 }
+
+module "webchat-browser-monitor" {
+  source = "./modules/monitors/webchat"
+
+  domain_name = var.environment == "production" ? "home.account.gov.uk" : "home.integration.account.gov.uk"
+  enabled     = var.environment == "production" ? false : true
+  frequency   = var.environment == "production" ? 15 : 60
+}


### PR DESCRIPTION
# Description:

We are introducing a JS widget on the contact page that will load a webchat client. This will give users another route to get support from One Login.

The webchat is a service hosted by one of our suppliers and we have limited monitoring available to us.

Add a new browser monitor that loads the English and Welsh contact pages and waits for the 'start webchat' button to appear. This button is injected by the JS, so once it appears we know that our supplier's origin is up and that the webchat has successfully loaded enough for a user to open the chat. The monitor will timeout and fail if the button's not appeared after 10 seconds. 

The English and Welsh chats are deployed as two separate applications by our supplier, so it's necessary to load both languages.

The monitor is configured to check against our integration in the non-production Dynatrace and production in the production Dynatrace.

I've set `enabled = false` for the production Dynatrace for now as we're not expecting to launch to production until at least next week. The chat is up and running in integration so that's enabled.

## Ticket number:
[OLH-1698](https://govukverify.atlassian.net/browse/OLH-1698)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence

This PR introduces a new monitor and doesn't change any existing configuration

- [x] I have tested this

I've clickops'd this [same monitor in the non-production Dynatrace](https://khw46367.live.dynatrace.com/ui/browser-monitor/SYNTHETIC_TEST-14F0C756067E0843?gtf=-2h&gf=-821220431582708962) and checked the wait-for logic does work.


[OLH-1698]: https://govukverify.atlassian.net/browse/OLH-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ