### PR TITLE
Create `di-auth-check-experian` dashboards

### DIFF
--- a/dashboards.tf
+++ b/dashboards.tf
@@ -221,6 +221,42 @@ resource "dynatrace_dashboard_sharing" "aws_service_quotas" {
   }
 }
 
+### Authentication ###
+
+module "di_auth_check_experian_build_dashboard" {
+  count  = local.is_production ? 0 : 1
+  source = "./dashboards/authentication/di-auth-check-experian"
+
+  api_account_id          = "761723964695"
+  check_account_id        = "851725166715"
+  application_environment = "build"
+}
+module "di_auth_check_experian_staging_dashboard" {
+  count  = local.is_production ? 0 : 1
+  source = "./dashboards/authentication/di-auth-check-experian"
+
+  api_account_id          = "758531536632"
+  check_account_id        = "891377189576"
+  application_environment = "staging"
+}
+module "di_auth_check_experian_integration_dashboard" {
+  count  = local.is_production ? 0 : 1
+  source = "./dashboards/authentication/di-auth-check-experian"
+
+  api_account_id          = "761723964695"
+  check_account_id        = "211125427676"
+  application_environment = "integration"
+}
+module "di_auth_check_experian_production_dashboard" {
+  count  = local.is_production ? 1 : 0
+  source = "./dashboards/authentication/di-auth-check-experian"
+
+  api_account_id          = "172348255554"
+  check_account_id        = "637423504848"
+  application_environment = "production"
+}
+
+
 ### Core ###
 
 module "core_lambda_metrics_dashboard" {

--- a/dashboards/authentication/di-auth-check-experian/di-auth-check-experian.json.tpl
+++ b/dashboards/authentication/di-auth-check-experian/di-auth-check-experian.json.tpl
@@ -1,0 +1,326 @@
+{
+  "metadata": {
+  },
+  "dashboardMetadata": {
+    "name": "di-auth-check-experian-${application_environment}",
+    "shared": true,
+    "owner": "matt.votsikas-mclean@digital.cabinet-office.gov.uk",
+    "hasConsistentColors": false
+  },
+  "tiles": [
+    {
+      "name": "SQS message counts",
+      "nameSize": "",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 570,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion",
+          "spaceAggregation": "MAX",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "${check_account_id}",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "${api_account_id}",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "PendingEmailCheckResultsQueue",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "${application_environment}-pending-email-check-queue",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "PendingEmailCheckResultsDeadLetterQueue",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "${application_environment}-pending-email-check-dlq",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion:filter(and(or(eq(\"aws.account.id\",\"${check_account_id}\"),eq(\"aws.account.id\",\"${api_account_id}\")),or(eq(queuename,PendingEmailCheckResultsQueue),eq(queuename,PendingEmailCheckResultsDeadLetterQueue),eq(queuename,${application_environment}-pending-email-check-dlq),eq(queuename,${application_environment}-pending-email-check-queue)))):splitBy(\"aws.account.id\",queuename):max:sort(value(max,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 570,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "There should be very little messages in a queue. If the number is building up notably over time it indicates an issue clearing the queues. If this happens, investigate.\n\nAny messages in a DLQ queue will not clear themselves and require someone to investigate and resolve."
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 570,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "The oldest message in any of these queues should really be no more than a minute, with the vast majority a few seconds.\n\nLarge message ages indicate an issue. Investigate."
+    },
+    {
+      "name": "SQS oldest message ages",
+      "nameSize": "",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 0,
+        "width": 570,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "${api_account_id}",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "${check_account_id}",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "PendingEmailCheckResultsQueue",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "${application_environment}-pending-email-check-queue",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(\"aws.account.id\",\"${check_account_id}\"),eq(\"aws.account.id\",\"${api_account_id}\")),or(eq(queuename,PendingEmailCheckResultsQueue),eq(queuename,${application_environment}-pending-email-check-queue)))):splitBy(\"aws.account.id\",queuename):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    }
+  ]
+}

--- a/dashboards/authentication/di-auth-check-experian/main.tf
+++ b/dashboards/authentication/di-auth-check-experian/main.tf
@@ -1,0 +1,33 @@
+locals {
+  check_experian = {
+    api_account_id          = var.api_account_id
+    check_account_id        = var.check_account_id
+    application_environment = var.application_environment
+  }
+}
+
+resource "dynatrace_json_dashboard" "main" {
+  contents = templatefile("${path.module}/di-auth-check-experian.json.tpl", local.check_experian)
+}
+
+data "dynatrace_iam_group" "all" {
+  name = "all"
+}
+
+resource "dynatrace_dashboard_sharing" "main" {
+  dashboard_id = dynatrace_json_dashboard.main.id
+
+  enabled = true
+
+  permissions {
+    permission {
+      level = "VIEW"
+      type  = "ALL"
+    }
+    permission {
+      id    = data.dynatrace_iam_group.all.id
+      level = "VIEW"
+      type  = "GROUP"
+    }
+  }
+}

--- a/dashboards/authentication/di-auth-check-experian/site.tf
+++ b/dashboards/authentication/di-auth-check-experian/site.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    dynatrace = {
+      source  = "dynatrace-oss/dynatrace"
+      version = "1.49.1"
+    }
+  }
+}

--- a/dashboards/authentication/di-auth-check-experian/variables.tf
+++ b/dashboards/authentication/di-auth-check-experian/variables.tf
@@ -1,0 +1,11 @@
+variable "api_account_id" {
+  description = "ID for the Auth API AWS account"
+}
+
+variable "check_account_id" {
+  description = "ID for the Auth Check Experian AWS account"
+}
+
+variable "application_environment" {
+  description = "Environment of the application within the Auth Check Experian AWS account"
+}


### PR DESCRIPTION
# Description:

Create a dashboard from a template for `build`, `staging`, `integration` and `production` environments. This allows us a place to gain an insight into the internal workings of the check-experian features.

These dashboards are expected to be augmented as we develop the new featuresets.

## Ticket number:
[AUT-2274](https://govukverify.atlassian.net/browse/AUT-2274?atlOrigin=eyJpIjoiNTI2N2Y0MGMyZWE5NGJiZWFiNDdlMzRiYzEyMTUzNTAiLCJwIjoiaiJ9)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[AUT-2274]: https://govukverify.atlassian.net/browse/AUT-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ