### PR TITLE
Added missing detection rule for Experian

### DIFF
--- a/settings_service_detection.tf
+++ b/settings_service_detection.tf
@@ -260,6 +260,34 @@ resource "dynatrace_service_external_web_request" "Post_Office" {
   }
 }
 
+resource "dynatrace_service_external_web_request" "Experian" {
+  name    = "Experian"
+  enabled = true
+  conditions {
+    condition {
+      attribute              = "HostName"
+      compare_operation_type = "StringEndsWith"
+      text_values            = ["uk-api.experian.com"]
+    }
+  }
+  id_contributors {
+    port_for_service_id = false
+    application_id {
+      enable_id_contributor = false
+    }
+    context_root {
+      enable_id_contributor = false
+    }
+    public_domain_name {
+      enable_id_contributor = true
+      service_id_contributor {
+        contribution_type   = "OriginalValue"
+        copy_from_host_name = true
+      }
+    }
+  }
+}
+
 # Service detection rules for External Web Requests 
 resource "dynatrace_service_external_web_service" "Redis" {
   name    = "Redis"


### PR DESCRIPTION
# Description:
Added in missing service detection rule for Experian.

## Ticket number:
PSREOBS-161 (noticed while creating the Service Dashboard)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
