### PR TITLE
AUT-2688: Add authentication account interventions dashboards

### DIFF
--- a/dashboards.tf
+++ b/dashboards.tf
@@ -395,6 +395,23 @@ module "orch_ais_integration" {
   path   = "orchestration/account-interventions-integration.json"
 }
 
+# Authentication
+module "auth_ais_production" {
+  count  = local.is_production ? 1 : 0
+  source = "./modules/dashboard"
+  path   = "authentication/account-interventions-prod.json"
+}
+module "auth_ais_staging" {
+  count  = local.is_production ? 0 : 1
+  source = "./modules/dashboard"
+  path   = "authentication/account-interventions-staging.json"
+}
+module "aith_ais_integration" {
+  count  = local.is_production ? 0 : 1
+  source = "./modules/dashboard"
+  path   = "authentication/account-interventions-integration.json"
+}
+
 ### SLA ###
 module "core_sla_dashboard" {
   source = "./modules/dashboard"

--- a/dashboards/authentication/account-interventions-integration.json
+++ b/dashboards/authentication/account-interventions-integration.json
@@ -1,0 +1,320 @@
+{
+  "metadata": {
+    "configurationVersions": [
+      7
+    ],
+    "clusterVersion": "1.289.80.20240411-174814"
+  },
+  "dashboardMetadata": {
+    "name": "Authentication - Account Interventions (Integration)",
+    "shared": false,
+    "owner": "becka.lelew@digital.cabinet-office.gov.uk",
+    "dashboardFilter": {
+      "managementZone": {
+        "id": "-8478320789215232343",
+        "name": "[AWS] gds-di-development"
+      }
+    },
+    "tags": [
+      "authentication"
+    ],
+    "hasConsistentColors": false
+  },
+  "tiles": [
+    {
+      "name": "Ignored errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 266,
+        "left": 0,
+        "width": 228,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:filter(contains(\"loggroup\",\"integration\")):splitBy():count:default(0,always)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:filter(contains(loggroup,integration)):splitBy():count:default(0,always)):limit(100):names:fold(auto)",
+        "resolution=null&(cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:filter(contains(loggroup,integration)):splitBy():count:default(0,always))"
+      ]
+    },
+    {
+      "name": "Interventions Received",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 760,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,true),contains(\"loggroup\",\"integration\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,false),contains(\"loggroup\",\"integration\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,false),eq(reproveidentity,false),eq(resetpassword,false),contains(\"loggroup\",\"integration\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,false),contains(\"loggroup\",\"integration\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,true),contains(\"loggroup\",\"integration\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,\"true\"),eq(resetpassword,true),contains(\"loggroup\",\"integration\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Blocked"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#471e64"
+              }
+            ]
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Suspended"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "No intervention"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reprove ID"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reset Password"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reset+Reprove"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "E",
+                "F"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,true),contains(loggroup,integration))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,false),contains(loggroup,integration))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,false),eq(reproveidentity,false),eq(resetpassword,false),contains(loggroup,integration))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,false),contains(loggroup,integration))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,true),contains(loggroup,integration))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,true),contains(loggroup,integration))):splitBy():count):limit(100):names"
+      ]
+    }
+  ]
+}

--- a/dashboards/authentication/account-interventions-prod.json
+++ b/dashboards/authentication/account-interventions-prod.json
@@ -1,0 +1,320 @@
+{
+  "metadata": {
+    "configurationVersions": [
+      7
+    ],
+    "clusterVersion": "1.289.80.20240411-174814"
+  },
+  "dashboardMetadata": {
+    "name": "Authentication - Account Interventions (Production)",
+    "shared": false,
+    "owner": "becka.lelew@digital.cabinet-office.gov.uk",
+    "dashboardFilter": {
+      "managementZone": {
+        "id": "-8478320789215232343",
+        "name": "[AWS] gds-di-development"
+      }
+    },
+    "tags": [
+      "authentication"
+    ],
+    "hasConsistentColors": false
+  },
+  "tiles": [
+    {
+      "name": "Ignored errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 266,
+        "left": 0,
+        "width": 228,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:filter(contains(\"loggroup\",\"production\")):splitBy():count:default(0,always)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:splitBy():count:default(0,always)):limit(100):names:fold(auto)",
+        "resolution=null&(cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:splitBy():count:default(0,always))"
+      ]
+    },
+    {
+      "name": "Interventions Received",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 760,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(eq(blocked,true)):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,false))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,false),eq(reproveidentity,false),eq(resetpassword,false))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,false))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,true))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,true))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Blocked"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#471e64"
+              }
+            ]
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Suspended"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "No intervention"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reprove ID"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reset Password"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reset+Reprove"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "E",
+                "F"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,true),contains(loggroup,production))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,false),contains(loggroup,production))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,false),eq(reproveidentity,false),eq(resetpassword,false),contains(loggroup,production))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,false),contains(loggroup,production))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,true),contains(loggroup,production))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,true),contains(loggroup,production))):splitBy():count):limit(100):names"
+      ]
+    }
+  ]
+}

--- a/dashboards/authentication/account-interventions-staging.json
+++ b/dashboards/authentication/account-interventions-staging.json
@@ -1,0 +1,320 @@
+{
+  "metadata": {
+    "configurationVersions": [
+      7
+    ],
+    "clusterVersion": "1.289.80.20240411-174814"
+  },
+  "dashboardMetadata": {
+    "name": "Authentication - Account Interventions (Staging)",
+    "shared": false,
+    "owner": "becka.lelew@digital.cabinet-office.gov.uk",
+    "dashboardFilter": {
+      "managementZone": {
+        "id": "107910556524230820",
+        "name": "[AWS] di-auth-staging"
+      }
+    },
+    "tags": [
+      "authentication"
+    ],
+    "hasConsistentColors": false
+  },
+  "tiles": [
+    {
+      "name": "Ignored errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 266,
+        "left": 0,
+        "width": 228,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:filter(contains(\"loggroup\",\"staging\")):splitBy():count:default(0,always)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:filter(contains(loggroup,staging)):splitBy():count:default(0,always)):limit(100):names:fold(auto)",
+        "resolution=null&(cloud.aws.authentication.authAisErrorIgnoredByAccountIdEnvironmentLogGroupRegionServiceNameServiceType:filter(contains(loggroup,staging)):splitBy():count:default(0,always))"
+      ]
+    },
+    {
+      "name": "Interventions Received",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 760,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,true),contains(\"loggroup\",\"staging\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,false),contains(\"loggroup\",\"staging\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,false),eq(reproveidentity,false),eq(resetpassword,false),contains(\"loggroup\",\"staging\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,false),contains(\"loggroup\",\"staging\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,true),contains(\"loggroup\",\"staging\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,\"true\"),eq(resetpassword,true),contains(\"loggroup\",\"staging\"))):splitBy():count",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Blocked"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#471e64"
+              }
+            ]
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Suspended"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "No intervention"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reprove ID"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reset Password"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Reset+Reprove"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "E",
+                "F"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,true),contains(loggroup,staging))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,false),contains(loggroup,staging))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,false),eq(reproveidentity,false),eq(resetpassword,false),contains(loggroup,staging))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,false),contains(loggroup,staging))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,false),eq(resetpassword,true),contains(loggroup,staging))):splitBy():count):limit(100):names,(cloud.aws.authentication.authAisResultByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeblockedreproveIdentityresetPasswordsuspended:filter(and(eq(blocked,false),eq(suspended,true),eq(reproveidentity,true),eq(resetpassword,true),contains(loggroup,staging))):splitBy():count):limit(100):names"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Description:

Adds dashboards for authentication's interaction with the account interventions service, similar to orchestration's dashboards (exact information presented differs slightly).

## Ticket number:
AUT-2688

## Related PRs

Equivalent PR adding similar for orchestration: https://github.com/govuk-one-login/observability-configuration/pull/118