### PR TITLE
ATB-1593 | Update Dynatrace Dashboard queries that use ext: to cloud.aws instead

### DIFF
--- a/dashboards/account-interventions-service/account_interventions_service_dashboard.json
+++ b/dashboards/account-interventions-service/account_interventions_service_dashboard.json
@@ -5511,9 +5511,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device"
+            "apiname"
           ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(min)",
+          "metricSelector": "cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(min)",
           "rate": "NONE",
           "enabled": true
         },
@@ -5522,9 +5522,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device"
+            "apiname"
           ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(avg)",
+          "metricSelector": "cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(avg)",
           "rate": "NONE",
           "enabled": true
         },
@@ -5533,9 +5533,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device"
+            "apiname"
           ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(95))",
+          "metricSelector": "cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):avg:fold(percentile(95))",
           "rate": "NONE",
           "enabled": true
         },
@@ -5544,9 +5544,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device"
+            "apiname"
           ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(99))",
+          "metricSelector": "cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):avg:fold(percentile(99))",
           "rate": "NONE",
           "enabled": true
         },
@@ -5555,9 +5555,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device"
+            "apiname"
           ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(max) ",
+          "metricSelector": "cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(max)",
           "rate": "NONE",
           "enabled": true
         }
@@ -5570,7 +5570,7 @@
         "rules": [
           {
             "matcher": "A:",
-            "unitTransform": "MilliSecond",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "PURPLE",
@@ -5581,7 +5581,7 @@
           },
           {
             "matcher": "B:",
-            "unitTransform": "MilliSecond",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "DEFAULT",
@@ -5592,7 +5592,7 @@
           },
           {
             "matcher": "C:",
-            "unitTransform": "MilliSecond",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "DEFAULT",
@@ -5603,7 +5603,7 @@
           },
           {
             "matcher": "D:",
-            "unitTransform": "MilliSecond",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "DEFAULT",
@@ -5614,7 +5614,7 @@
           },
           {
             "matcher": "E:",
-            "unitTransform": "MilliSecond",
+            "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
               "color": "DEFAULT",
@@ -5748,7 +5748,8 @@
             "B:dt.entity.custom_device.name",
             "C:dt.entity.custom_device.name",
             "D:dt.entity.custom_device.name",
-            "E:dt.entity.custom_device.name"
+            "E:dt.entity.custom_device.name",
+            "F:apiname.name"
           ]
         },
         "graphChartSettings": {
@@ -5764,7 +5765,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(min)):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(avg)):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(95))):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(99))):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(max)):names:fold(auto)"
+        "resolution=null&(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(min)):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(avg)):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):avg:fold(percentile(95))):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):avg:fold(percentile(99))):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(max)):names:fold(auto)"
       ]
     }
   ]

--- a/dashboards/account-interventions-service/account_interventions_service_dashboard.json
+++ b/dashboards/account-interventions-service/account_interventions_service_dashboard.json
@@ -3830,317 +3830,6 @@
       ]
     },
     {
-      "name": "Max Quota Usage (%) - CryptographicOperationsSymmetric",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 342,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(\"resource\"):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,00",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
-      "name": "DescribeKey - Max 2,000/s",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 646,
-        "left": 1444,
-        "width": 570,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,\"DescribeKey\")):splitBy(resource):count:rate(1s)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {
-          "hideLegend": true
-        },
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "value": 1000,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 2000,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):count:rate(1s)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - DescribeKey",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 646,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,\"DescribeKey\")):splitBy(\"resource\"):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
       "name": "DescribeSecret/GetSecretValue - Max 10,000/s",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -4245,106 +3934,6 @@
       ]
     },
     {
-      "name": "Max Quota Usage (%) - DescribeSecret/GetSecretValue",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1026,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeKey\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"resource\"):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(resource,DescribeKey),eq(resource,GetSecretValue))):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(resource,DescribeKey),eq(resource,GetSecretValue))):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
       "name": "Invocations - Max 1,000",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -4443,506 +4032,6 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):count):limit(100):names"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - Invocations",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1406,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"Invocations\")):splitBy(\"resource\"):sum/1000)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):sum/1000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):sum/1000)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - ListMetrics",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1824,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"ListMetrics\")):splitBy(\"resource\"):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,ListMetrics)):splitBy(resource):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,ListMetrics)):splitBy(resource):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - GetMetricData",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2166,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"GetMetricData\")):splitBy(\"resource\"):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,GetMetricData)):splitBy(resource):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,GetMetricData)):splitBy(resource):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - PutMetricData",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2508,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutMetricData\")):splitBy(\"resource\"):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutMetricData)):splitBy(resource):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutMetricData)):splitBy(resource):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - PutLogEvents",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2850,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource"
-          ],
-          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutLogEvents\")):splitBy(\"resource\"):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutLogEvents)):splitBy(resource):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutLogEvents)):splitBy(resource):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max))"
       ]
     },
     {
@@ -5766,6 +4855,917 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(min)):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(avg)):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):avg:fold(percentile(95))):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):avg:fold(percentile(99))):names:fold(auto),(cloud.aws.apigateway.latencyByAccountIdApiNameRegion:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):fold(max)):names:fold(auto)"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - CryptographicOperationsSymmetric",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 342,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(\"resource\"):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,00",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "CryptographicOperationsSymmetric"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - DescribeKey",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 646,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,\"DescribeKey\")):splitBy(\"resource\"):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "DescribeKey"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - DescribeSecret/GetSecretValue",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1026,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeKey\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"resource\"):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "DescribeKey/GetSecretValue"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(resource,DescribeKey),eq(resource,GetSecretValue))):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(resource,DescribeKey),eq(resource,GetSecretValue))):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - Invocations",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1406,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"Invocations\")):splitBy(\"resource\"):sum/1000)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Invocations"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):sum/1000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):sum/1000)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - ListMetrics",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1824,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"ListMetrics\")):splitBy(\"resource\"):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "ListMetrics"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,ListMetrics)):splitBy(resource):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,ListMetrics)):splitBy(resource):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - GetMetricData",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2166,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"GetMetricData\")):splitBy(\"resource\"):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "GetMetricData"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,GetMetricData)):splitBy(resource):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,GetMetricData)):splitBy(resource):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - PutMetricData",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2508,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutMetricData\")):splitBy(\"resource\"):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "PutMetricData"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutMetricData)):splitBy(resource):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutMetricData)):splitBy(resource):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - PutLogEvents",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2850,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutLogEvents\")):splitBy(\"resource\"):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "PutLogEvents"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutLogEvents)):splitBy(resource):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutLogEvents)):splitBy(resource):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "DescribeKey - Max 2,000/s",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 646,
+        "left": 1444,
+        "width": 570,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,\"DescribeKey\")):splitBy(resource):count:rate(1s)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": true
+        },
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "CallCount"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "value": 1000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 2000,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):count:rate(1s)):limit(100):names"
       ]
     }
   ]

--- a/dashboards/account-interventions-service/account_interventions_service_dashboard.json
+++ b/dashboards/account-interventions-service/account_interventions_service_dashboard.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.287.90.20240313-050452"
+    "clusterVersion": "1.289.95.20240417-174357"
   },
   "dashboardMetadata": {
     "name": "Accounts Intervention Service",
@@ -1096,185 +1096,6 @@
       ]
     },
     {
-      "name": "API Responses",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 38,
-        "left": 722,
-        "width": 494,
-        "height": 152
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "server-side-response-time-metric",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.countSum:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\") - ext:cloud.aws.apiGateway.4xxErrorSum:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\") - ext:cloud.aws.apiGateway.5xxErrorSum:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.4xxErrorSum:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.5xxErrorSum:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "TABLE",
-        "global": {
-          "hideLegend": false
-        },
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "0",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "LINE",
-              "alias": "2XX Responses"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "4XX Responses"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "5XX Errors"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "A",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "columnId": "4XXError Sum",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "B",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "columnId": "5XXError Sum",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "C",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "isThresholdBackgroundAppliedToCell": true,
-          "hiddenColumns": [
-            "A:Custom Device",
-            "A:dt.entity.custom_device.name",
-            "B:dt.entity.custom_device.name",
-            "C:dt.entity.custom_device.name"
-          ]
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": false,
-          "showLabels": true
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(ext:cloud.aws.apiGateway.countSum:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")-ext:cloud.aws.apiGateway.\"4xxErrorSum\":filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")-ext:cloud.aws.apiGateway.\"5xxErrorSum\":filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")):names,(ext:cloud.aws.apiGateway.\"4xxErrorSum\":filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")):names,(ext:cloud.aws.apiGateway.\"5xxErrorSum\":filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")):names"
-      ]
-    },
-    {
       "name": "Lambda Latency",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -1541,143 +1362,6 @@
       },
       "metricExpressions": [
         "resolution=Inf&(builtin:service.response.server:filter(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.service\"):sort(value(auto,descending)):min:limit(100)):names,(builtin:service.response.server:filter(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.service\"):sort(value(auto,descending)):avg:limit(100)):names,(builtin:service.response.server:filter(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.service\"):sort(value(auto,descending)):percentile(95):limit(100)):names,(builtin:service.response.server:filter(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.service\"):sort(value(auto,descending)):percentile(99):limit(100)):names,(builtin:service.response.server:filter(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.service\"):sort(value(auto,descending)):max:limit(100)):names"
-      ]
-    },
-    {
-      "name": "SQS Stats",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 418,
-        "left": 722,
-        "width": 494,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Honeycomb",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.sqs.approximateAgeOfOldestMessage:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):max",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.sqs.numberOfMessagesSentSum:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "TABLE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Oldest Message Age"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "columnId": "ApproximateAgeOfOldestMessage",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 60,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 600,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "B",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "columnId": "NumberOfMessagesSent Sum",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "C",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "isThresholdBackgroundAppliedToCell": true,
-          "hiddenColumns": [
-            "A:dt.entity.custom_device.name",
-            "B:dt.entity.custom_device.name",
-            "C:dt.entity.custom_device.name"
-          ]
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(ext:cloud.aws.sqs.approximateAgeOfOldestMessage:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):max):names,(ext:cloud.aws.sqs.numberOfMessagesSentSum:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\")):names"
       ]
     },
     {
@@ -3552,276 +3236,6 @@
       ]
     },
     {
-      "name": "API Latency",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 38,
-        "left": 0,
-        "width": 722,
-        "height": 152
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "server-side-response-time-metric",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(min)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(avg)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):max:fold(percentile(95))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "D",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):max:fold(percentile(99))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "E",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
-          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "TABLE",
-        "global": {
-          "hideLegend": false
-        },
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "MilliSecond",
-            "valueFormat": "0",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "LINE",
-              "alias": "Min"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "MilliSecond",
-            "valueFormat": "0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Avg"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "MilliSecond",
-            "valueFormat": "0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "P95"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "D:",
-            "unitTransform": "MilliSecond",
-            "valueFormat": "0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "P99"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "E:",
-            "unitTransform": "MilliSecond",
-            "valueFormat": "0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Max"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "columnId": "Latency",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 500,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1000,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "B",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "columnId": "Latency",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 500,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1000,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "C",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "columnId": "Latency",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 1000,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 2000,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "D",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "columnId": "Latency",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 1000,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 2000,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "E",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "columnId": "Latency",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 200,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 500,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "A",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "isThresholdBackgroundAppliedToCell": true,
-          "hiddenColumns": [
-            "A:Custom Device",
-            "A:dt.entity.custom_device.name",
-            "B:dt.entity.custom_device.name",
-            "C:dt.entity.custom_device.name",
-            "D:dt.entity.custom_device.name",
-            "E:dt.entity.custom_device.name"
-          ]
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": false,
-          "showLabels": true
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(min)):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(avg)):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):max:fold(percentile(95))):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):max:fold(percentile(99))):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(max)):names:fold(auto)"
-      ]
-    },
-    {
       "name": "Milliseconds - Event Delivery Latency",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -4088,6 +3502,224 @@
       "isAutoRefreshDisabled": false
     },
     {
+      "name": "Secrets Manager",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 988,
+        "left": 1444,
+        "width": 304,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "Lambda",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 1368,
+        "left": 1444,
+        "width": 304,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "CloudWatch",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 1444,
+        "width": 304,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "API Responses",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 722,
+        "width": 494,
+        "height": 152
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "server-side-response-time-metric",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(\"apiname\",\"ais-main-PrivateRestApi\")))):splitBy(\"apiname\"):sum -\ncloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(\"apiname\"):sum -\ncloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "2XX Response"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "4XX Responses"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "5XX Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "columnId": "4XXError",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "columnId": "5XXError",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "C",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "isThresholdBackgroundAppliedToCell": true,
+          "hiddenColumns": [
+            "A:apiname",
+            "A:apiname.name",
+            "B:apiname.name",
+            "C:apiname.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": false,
+          "showLabels": true
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum - cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum - cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum):names,(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,ais-main-PrivateRestApi)))):splitBy(apiname):sum):names"
+      ]
+    },
+    {
       "name": "CryptographicOperationsSymmetric - Max 10,000/s",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -4106,10 +3738,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):count:rate(1s)",
           "rate": "NONE",
           "enabled": true
         }
@@ -4195,7 +3826,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):count:rate(1s)):limit(100):names"
       ]
     },
     {
@@ -4217,10 +3848,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(\"resource\"):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
           "rate": "NONE",
           "enabled": true
         }
@@ -4295,8 +3925,8 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,CryptographicOperationsSymmetric)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,CryptographicOperationsSymmetric)):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
       ]
     },
     {
@@ -4318,10 +3948,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,DescribeKey)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,\"DescribeKey\")):splitBy(resource):count:rate(1s)",
           "rate": "NONE",
           "enabled": true
         }
@@ -4408,7 +4037,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,DescribeKey)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):count:rate(1s)):limit(100):names"
       ]
     },
     {
@@ -4430,10 +4059,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,DescribeKey)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/2000)*100):setUnit(Percent)):fold(max)",
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,\"DescribeKey\")):splitBy(\"resource\"):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max)",
           "rate": "NONE",
           "enabled": true
         }
@@ -4508,8 +4136,8 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,DescribeKey)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/2000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,DescribeKey)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/2000)*100):setUnit(Percent)):fold(max))"
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,DescribeKey)):splitBy(resource):sum:rate(1s)/2000)*100):setUnit(Percent)):fold(max))"
       ]
     },
     {
@@ -4531,9 +4159,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device"
+            "service"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(\"Resource\",\"DescribeSecret\"),eq(\"Resource\",\"GetSecretValue\"))):splitBy(\"dt.entity.custom_device\"):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeSecret\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"service\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -4613,7 +4241,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(Resource,DescribeSecret),eq(Resource,GetSecretValue))):splitBy(\"dt.entity.custom_device\"):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(resource,DescribeSecret),eq(resource,GetSecretValue))):splitBy(service):sum:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -4635,10 +4263,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(\"Resource\",\"DescribeSecret\"),eq(\"Resource\",\"GetSecretValue\"))):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeKey\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"resource\"):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)",
           "rate": "NONE",
           "enabled": true
         }
@@ -4713,38 +4340,12 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(Resource,DescribeSecret),eq(Resource,GetSecretValue))):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(or(eq(Resource,DescribeSecret),eq(Resource,GetSecretValue))):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(resource,DescribeKey),eq(resource,GetSecretValue))):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(resource,DescribeKey),eq(resource,GetSecretValue))):splitBy(resource):sum:rate(1s)/10000)*100):setUnit(Percent)):fold(max))"
       ]
     },
     {
-      "name": "Secrets Manager",
-      "tileType": "HEADER",
-      "configured": true,
-      "bounds": {
-        "top": 988,
-        "left": 1444,
-        "width": 304,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false
-    },
-    {
-      "name": "Lambda",
-      "tileType": "HEADER",
-      "configured": true,
-      "bounds": {
-        "top": 1368,
-        "left": 1444,
-        "width": 304,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false
-    },
-    {
-      "name": "Invocations - Max 1,000/s",
+      "name": "Invocations - Max 1,000",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
@@ -4762,10 +4363,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,Invocations)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"Invocations\")):splitBy(\"resource\"):count",
           "rate": "NONE",
           "enabled": true
         }
@@ -4842,7 +4442,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,Invocations)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):count):limit(100):names"
       ]
     },
     {
@@ -4864,10 +4464,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,\"Invocations\")):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/1000)*100):setUnit(Percent)):fold(max)",
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"Invocations\")):splitBy(\"resource\"):sum/1000)*100):setUnit(Percent)):fold(max)",
           "rate": "NONE",
           "enabled": true
         }
@@ -4942,8 +4541,408 @@
         "foldAggregation": "MAX"
       },
       "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,Invocations)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/1000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,Invocations)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/1000)*100):setUnit(Percent)):fold(max))"
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):sum/1000)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,Invocations)):splitBy(resource):sum/1000)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - ListMetrics",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1824,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"ListMetrics\")):splitBy(\"resource\"):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,ListMetrics)):splitBy(resource):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,ListMetrics)):splitBy(resource):sum:rate(1s)/25)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - GetMetricData",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2166,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"GetMetricData\")):splitBy(\"resource\"):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,GetMetricData)):splitBy(resource):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,GetMetricData)):splitBy(resource):sum:rate(1s)/50)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - PutMetricData",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2508,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutMetricData\")):splitBy(\"resource\"):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutMetricData)):splitBy(resource):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutMetricData)):splitBy(resource):sum:rate(1s)/500)*100):setUnit(Percent)):fold(max))"
+      ]
+    },
+    {
+      "name": "Max Quota Usage (%) - PutLogEvents",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2850,
+        "left": 2052,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "(((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutLogEvents\")):splitBy(\"resource\"):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Percent",
+            "valueFormat": "0,0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 80,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 100,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutLogEvents)):splitBy(resource):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
+        "resolution=null&((((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutLogEvents)):splitBy(resource):sum:rate(1s)/2500)*100):setUnit(Percent)):fold(max))"
       ]
     },
     {
@@ -4965,9 +4964,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:splitBy(Resource):filter(eq(\"Resource\",\"ListMetrics\")):sort(dimension(\"Resource\",ascending)):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,\"ListMetrics\")):splitBy(resource):count:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -5050,122 +5049,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:splitBy(Resource):filter(eq(Resource,ListMetrics)):sort(dimension(Resource,ascending)):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,ListMetrics)):splitBy(resource):count:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
-    },
-    {
-      "name": "Max Quota Usage (%) - ListMetrics",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1824,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,ListMetrics)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/25)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,ListMetrics)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/25)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,ListMetrics)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/25)*100):setUnit(Percent)):fold(max))"
-      ]
-    },
-    {
-      "name": "CloudWatch",
-      "tileType": "HEADER",
-      "configured": true,
-      "bounds": {
-        "top": 1748,
-        "left": 1444,
-        "width": 304,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false
     },
     {
       "name": "GetMetricData - Max 50/s",
@@ -5186,9 +5071,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:splitBy(Resource):filter(eq(\"Resource\",\"GetMetricData\")):sort(dimension(\"Resource\",ascending)):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"GetMetricData\")):splitBy(\"resource\"):count:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -5201,11 +5086,8 @@
         "rules": [
           {
             "matcher": "A:",
-            "unitTransform": "PerSecond",
-            "valueFormat": "auto",
             "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE"
+              "color": "DEFAULT"
             },
             "seriesOverrides": []
           }
@@ -5268,108 +5150,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:splitBy(Resource):filter(eq(Resource,GetMetricData)):sort(dimension(Resource,ascending)):rate(1s):setUnit(PerSecond)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - GetMetricData",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2166,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,GetMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/50)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,GetMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/50)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,GetMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/50)*100):setUnit(Percent)):fold(max))"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,GetMetricData)):splitBy(resource):count:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -5391,10 +5172,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutMetricData\")):splitBy(resource):count:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -5471,108 +5251,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Max Quota Usage (%) - PutMetricData",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2508,
-        "left": 2052,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/500)*100):setUnit(Percent)):fold(max)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "value": 80,
-                "color": "#f5d30f"
-              },
-              {
-                "value": 100,
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
-      },
-      "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutMetricData)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/500)*100):setUnit(Percent)):fold(max))"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutMetricData)):splitBy(resource):count:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
@@ -5594,9 +5273,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "Resource"
+            "resource"
           ],
-          "metricSelector": "ext:cloud.aws.usage.callCountSumByClassResourceType:splitBy(\"Resource\"):filter(eq(\"Resource\",\"PutLogEvents\")):rate(1s):setUnit(PerSecond)",
+          "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"PutLogEvents\")):splitBy(\"resource\"):count:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
         }
@@ -5609,11 +5288,8 @@
         "rules": [
           {
             "matcher": "A:",
-            "unitTransform": "PerSecond",
-            "valueFormat": "auto",
             "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE"
+              "color": "DEFAULT"
             },
             "seriesOverrides": []
           }
@@ -5676,48 +5352,69 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(ext:cloud.aws.usage.callCountSumByClassResourceType:splitBy(Resource):filter(eq(Resource,PutLogEvents)):rate(1s):setUnit(PerSecond)):limit(100):names"
+        "resolution=null&(cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(resource,PutLogEvents)):splitBy(resource):count:rate(1s):setUnit(PerSecond)):limit(100):names"
       ]
     },
     {
-      "name": "Max Quota Usage (%) - PutLogEvents",
+      "name": "SQS Stats",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2850,
-        "left": 2052,
-        "width": 304,
-        "height": 304
+        "top": 418,
+        "left": 722,
+        "width": 494,
+        "height": 228
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
+      "customName": "Honeycomb",
       "queries": [
         {
-          "id": "A",
+          "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
+            "queuename"
           ],
-          "metricSelector": "(((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutLogEvents)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/2500)*100):setUnit(Percent)):fold(max)",
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(contains(\"queuename\",\"ais-main\")):splitBy(\"queuename\"):max",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(contains(\"queuename\",\"ais-main\")):splitBy(\"queuename\"):sum",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
-        "type": "SINGLE_VALUE",
+        "type": "TABLE",
         "global": {},
         "rules": [
           {
-            "matcher": "A:",
-            "unitTransform": "Percent",
-            "valueFormat": "0,0",
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
             "properties": {
               "color": "DEFAULT",
               "seriesType": "LINE",
-              "alias": "ext:cloud.aws.usage.callCountSumByClassResourceType:filter(and(or(eq(Resource,CryptographicOperationsSymmetric)))):splitBy():count:rate(1s)/60*100:setUnit(Percent)"
+              "alias": "Oldest Message Age"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Messages Received"
             },
             "seriesOverrides": []
           }
@@ -5729,37 +5426,55 @@
           "yAxes": []
         },
         "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
+          "yAxis": "VALUE"
         },
         "thresholds": [
           {
             "axisTarget": "LEFT",
+            "columnId": "ApproximateAgeOfOldestMessage",
             "rules": [
               {
                 "value": 0,
                 "color": "#7dc540"
               },
               {
-                "value": 80,
+                "value": 60,
                 "color": "#f5d30f"
               },
               {
-                "value": 100,
+                "value": 600,
                 "color": "#dc172a"
               }
             ],
-            "queryId": "",
+            "queryId": "B",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesSent",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "C",
             "visible": true
           }
         ],
         "tableSettings": {
-          "hiddenColumns": []
+          "isThresholdBackgroundAppliedToCell": true,
+          "hiddenColumns": [
+            "B:queuename.name",
+            "D:queuename.name",
+            "C:queuename.name"
+          ]
         },
         "graphChartSettings": {
           "connectNulls": false
@@ -5771,13 +5486,285 @@
         }
       },
       "queriesSettings": {
-        "resolution": "",
-        "foldTransformation": "TOTAL",
-        "foldAggregation": "MAX"
+        "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutLogEvents)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/2500)*100):setUnit(Percent)):fold(max)):limit(100):names:fold(max)",
-        "resolution=null&((((ext:cloud.aws.usage.callCountSumByClassResourceType:filter(eq(Resource,PutLogEvents)):splitBy(\"dt.entity.custom_device\",Resource):rate(1s)/2500)*100):setUnit(Percent)):fold(max))"
+        "resolution=Inf&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(contains(queuename,ais-main)):splitBy(queuename):max):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(contains(queuename,ais-main)):splitBy(queuename):sum):names"
+      ]
+    },
+    {
+      "name": "API Latency",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 0,
+        "width": 722,
+        "height": 152
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "server-side-response-time-metric",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "dt.entity.custom_device"
+          ],
+          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(min)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "dt.entity.custom_device"
+          ],
+          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(avg)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "dt.entity.custom_device"
+          ],
+          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(95))",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "dt.entity.custom_device"
+          ],
+          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(99))",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "dt.entity.custom_device"
+          ],
+          "metricSelector": "ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\", entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(max) ",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "MilliSecond",
+            "valueFormat": "0",
+            "properties": {
+              "color": "PURPLE",
+              "seriesType": "LINE",
+              "alias": "Min"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "MilliSecond",
+            "valueFormat": "0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Avg"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "MilliSecond",
+            "valueFormat": "0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "P95"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "MilliSecond",
+            "valueFormat": "0",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "P99"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "MilliSecond",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Max"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Latency",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 500,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1000,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Latency",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 500,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1000,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "C",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Latency",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 1250,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 2500,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "D",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Latency",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 1000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 2000,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "E",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Latency",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "value": 200,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 500,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "isThresholdBackgroundAppliedToCell": true,
+          "hiddenColumns": [
+            "A:apiname",
+            "A:apiname.name",
+            "B:apiname.name",
+            "C:apiname.name",
+            "D:apiname.name",
+            "E:apiname.name",
+            "A:dt.entity.custom_device.name",
+            "B:dt.entity.custom_device.name",
+            "C:dt.entity.custom_device.name",
+            "D:dt.entity.custom_device.name",
+            "E:dt.entity.custom_device.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": false,
+          "showLabels": true
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(min)):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(avg)):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(95))):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):avg:fold(percentile(99))):names:fold(auto),(ext:cloud.aws.apiGateway.latency:filter(in(\"dt.entity.custom_device\",entitySelector(\"type(~\"CUSTOM_DEVICE~\"), entityName.contains(~\"ais-main-~\")\"))):splitBy(\"dt.entity.custom_device\"):fold(max)):names:fold(auto)"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
Update Dynatrace Dashboard queries that use ext: to cloud.aws instead 
## Ticket number:
[OBS-XXX]
ATB-1593 
## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
