### PR TITLE
AUT-2766- Adding Auth team to cloudfront Dashboard

### DIFF
--- a/dashboards-cloudfront.tf
+++ b/dashboards-cloudfront.tf
@@ -25,6 +25,12 @@ variable "teamscloudfront1" {
       awsaccprod = "821078365651"
       awsaccint  = "988112579449"
     }
+    "team-e" = {
+      owneremail = "pawankumar.kushwaha@digital.cabinet-office.gov.uk"
+      teamname   = "Auth - gds-di-production"
+      awsaccprod = "172348255554"
+      awsaccint  = "761723964695"
+    }
   }
 }
 


### PR DESCRIPTION
# Description:
AUT-2766- Adding Auth team to monitor traffic to cloudfront on Dynatrace Dashboard

## Ticket number:
AUT-2766 


