### PR TITLE
fix orange otg dashboards, removed id from templates.

### DIFF
--- a/dashboards/orange/dashboard-builder/templates/otg-cri.tpl.json
+++ b/dashboards/orange/dashboard-builder/templates/otg-cri.tpl.json
@@ -5,7 +5,6 @@
     ],
     "clusterVersion": "1.290.46.20240425-162131"
   },
-  "id": "149cbe17-497c-435b-9301-33d368ade191",
   "dashboardMetadata": {
     "name": "${team_name} OTG CRI ${application_environment}",
     "shared": true,

--- a/dashboards/orange/dashboard-builder/templates/otg-lambda-metrics.tpl.json
+++ b/dashboards/orange/dashboard-builder/templates/otg-lambda-metrics.tpl.json
@@ -5,7 +5,6 @@
     ],
     "clusterVersion": "1.290.46.20240425-162131"
   },
-  "id": "3196d19f-cedc-4db1-bf22-583ea4a13b63",
   "dashboardMetadata": {
     "name": "${team_name} OTG CRI Lambda Metrics ${application_environment}",
     "shared": false,


### PR DESCRIPTION
# Description:
fix orange otg dashboards, removed id from templates.

## Ticket number:
[OJ-2496]https://govukverify.atlassian.net/browse/OJ-2496

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[OJ-2496]: https://govukverify.atlassian.net/browse/OJ-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ