### PR TITLE
OJ-2517: Adds orange CRIs to cloudfront dashboards

### DIFF
--- a/dashboards-cloudfront.tf
+++ b/dashboards-cloudfront.tf
@@ -31,6 +31,24 @@ variable "teamscloudfront1" {
       awsaccprod = "172348255554"
       awsaccint  = "761723964695"
     }
+    "team-f" = {
+      owneremail = "cri-orange-team@digital.cabinet-office.gov.uk"
+      teamname   = "Orange - NINo-CRI"
+      awsaccprod = "239207391607"
+      awsaccint  = "488209198322"
+    }
+    "team-g" = {
+      owneremail = "cri-orange-team@digital.cabinet-office.gov.uk"
+      teamname   = "Orange - Address-CRI"
+      awsaccprod = "608988268245"
+      awsaccint  = "993720532118"
+    }
+    "team-h" = {
+      owneremail = "cri-orange-team@digital.cabinet-office.gov.uk"
+      teamname   = "Orange - Experian-KBV-CRI"
+      awsaccprod = "014243362159"
+      awsaccint  = "023997819930"
+    }
   }
 }
 


### PR DESCRIPTION
# Description:

Adds orange CRIs to cloudfront dashboards as per https://govukverify.atlassian.net/wiki/spaces/DID/pages/4097146881/Dynatrace+dashboard+to+help+you+through+the+deployment

## Ticket number:
[OJ-2517]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[OJ-2517]: https://govukverify.atlassian.net/browse/OJ-2517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ