### PR TITLE
Add WAF dashboard

### DIFF
--- a/dashboards/dev-platform/TEMPLATE_cloudfront_dashboard.json
+++ b/dashboards/dev-platform/TEMPLATE_cloudfront_dashboard.json
@@ -357,6 +357,171 @@
       "metricExpressions": [
         "resolution=null&(cloud.aws.applicationelb.requestCountByAccountIdLoadBalancerRegion:filter(and(or(eq(\"aws.account.id\",\"${awsaccprod}\")))):splitBy(loadbalancer,\"aws.account.id\"):sort(value(auto,descending))):limit(100):names"
       ]
+    },
+    {
+      "name": "WAF (Prod)",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 418,
+        "left": 0,
+        "width": 456,
+        "height": 418
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.wafv2.blockedRequestsByAccountIdRegionRuleWebACL",
+          "spaceAggregation": "SUM",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "webacl"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "${awsaccprod}",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "metric": "cloud.aws.wafv2.countedRequestsByAccountIdRegionRuleWebACL",
+          "spaceAggregation": "SUM",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "webacl"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "${awsaccprod}",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Blocked"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "LINE",
+              "alias": "Counted"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.wafv2.blockedRequestsByAccountIdRegionRuleWebACL:filter(and(or(eq(\"aws.account.id\",\"${awsaccprod}\")))):splitBy(webacl):sum:sort(value(sum,descending)):limit(20)):limit(100):names,(cloud.aws.wafv2.countedRequestsByAccountIdRegionRuleWebACL:filter(and(or(eq(\"aws.account.id\",\"${awsaccprod}\")))):splitBy(webacl):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
     }
   ]
 }


### PR DESCRIPTION
New WAF tile on CloudFront monitoring dashboards

- this may help TSD or teams notice if there is a problem with the Cloaking WAF especially
- part of the CloudFront initiative involves some WAF complexity so having this on a purpose-built dashboard seems sensible

https://govukverify.atlassian.net/browse/PLAT-4403
