### PR TITLE
PSREDEV-800 - Refactoring dev-platform dora dashboard deployments

### DIFF
--- a/dashboards-dora.tf
+++ b/dashboards-dora.tf
@@ -1,36 +1,46 @@
-# Please add your Team name and the Secure Pipelines you wish to graph
-# There are 3 template csv files you can choose to populate:
-# 1 - "template1" - if you want to track only 1 pipeline
-# 2 - "template2" - if you want to track only 2 pipelines
-# 3 - "template3" - if you want to track only 3 pipelines
+# Please add your Team name and the Secure Pipelines you wish to graph in the pipelines-list.csv
+# 
+# DO NOT USE template2.csv and template3.csv.
+# These are work-in-progress for continuous improvements and may be removed in future
 
-#######################################
-# 1 Secure Pipelines on the Dashboard
-#######################################
-resource "dynatrace_json_dashboard" "Team-DORA-Dashboards1" {
-  for_each = {
-    for f in csvdecode(file("./dashboards/dev-platform/template1.csv")) :
-    f.team => f
+locals {
+  secure_pipelines = {
+    for f in csvdecode(file("./dashboards/dev-platform/pipelines-list.csv")) :
+    "${f.team}-${f.samstackname1}" => f
   }
 
+  dora_dashboards2 = {
+    for f in csvdecode(file("./dashboards/dev-platform/template2.csv")) :
+    "${f.team}-${f.samstackname1}-${f.samstackname2}" => f
+  }
+
+  dora_dashboards3 = {
+    for f in csvdecode(file("./dashboards/dev-platform/template3.csv")) :
+    "${f.team}-${f.samstackname1}-${f.samstackname2}-${f.samstackname3}" => f
+  }
+}
+
+#######################################
+# Secure Pipelines on the Dashboard
+#######################################
+resource "dynatrace_json_dashboard" "Team-DORA-Dashboards1" {
+  for_each = local.secure_pipelines
+
   contents = templatefile("./dashboards/dev-platform/TEMPLATE1_dashboard.json", {
-    title         = each.value.samstackname1
+    title         = "${each.value.team} ${each.value.samstackname1}"
     owner         = each.value.email
     samstackname1 = each.value.samstackname1
   })
 }
 
 #######################################
-# 2 Secure Pipelines on the Dashboard
+# Test Dashboard with 2 pipelines
 #######################################
 resource "dynatrace_json_dashboard" "Team-DORA-Dashboards2" {
-  for_each = {
-    for f in csvdecode(file("./dashboards/dev-platform/template2.csv")) :
-    f.team => f
-  }
+  for_each = local.dora_dashboards2
 
   contents = templatefile("./dashboards/dev-platform/TEMPLATE2_dashboard.json", {
-    title         = "${each.value.samstackname1} - ${each.value.samstackname2}"
+    title         = "${each.value.team} ${each.value.samstackname1} ${each.value.samstackname2}"
     owner         = each.value.email
     samstackname1 = each.value.samstackname1
     samstackname2 = each.value.samstackname2
@@ -38,16 +48,13 @@ resource "dynatrace_json_dashboard" "Team-DORA-Dashboards2" {
 }
 
 #######################################
-# 3 Secure Pipelines on the Dashboard
+# Test Dashboard with 3 pipelines
 #######################################
 resource "dynatrace_json_dashboard" "Team-DORA-Dashboards3" {
-  for_each = {
-    for f in csvdecode(file("./dashboards/dev-platform/template3.csv")) :
-    f.team => f
-  }
+  for_each = local.dora_dashboards3
 
   contents = templatefile("./dashboards/dev-platform/TEMPLATE3_dashboard.json", {
-    title         = "${each.value.samstackname1} - ${each.value.samstackname2} - ${each.value.samstackname3}"
+    title         = "${each.value.team} ${each.value.samstackname1} ${each.value.samstackname2} ${each.value.samstackname3}"
     owner         = each.value.email
     samstackname1 = each.value.samstackname1
     samstackname2 = each.value.samstackname2
@@ -56,10 +63,7 @@ resource "dynatrace_json_dashboard" "Team-DORA-Dashboards3" {
 }
 
 resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards1" {
-  for_each = {
-    for f in csvdecode(file("./dashboards/dev-platform/template1.csv")) :
-    f.team => f
-  }
+  for_each = local.secure_pipelines
 
   dashboard_id = dynatrace_json_dashboard.Team-DORA-Dashboards1[each.key].id
   enabled      = true
@@ -77,10 +81,7 @@ resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards1" {
 }
 
 resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards2" {
-  for_each = {
-    for f in csvdecode(file("./dashboards/dev-platform/template2.csv")) :
-    f.team => f
-  }
+  for_each = local.dora_dashboards2
 
   dashboard_id = dynatrace_json_dashboard.Team-DORA-Dashboards2[each.key].id
   enabled      = true
@@ -98,10 +99,7 @@ resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards2" {
 }
 
 resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards3" {
-  for_each = {
-    for f in csvdecode(file("./dashboards/dev-platform/template3.csv")) :
-    f.team => f
-  }
+  for_each = local.dora_dashboards3
 
   dashboard_id = dynatrace_json_dashboard.Team-DORA-Dashboards3[each.key].id
   enabled      = true

--- a/dashboards-dora.tf
+++ b/dashboards-dora.tf
@@ -1,99 +1,21 @@
 # Please add your Team name and the Secure Pipelines you wish to graph
-# Below are 3 "variables" you can choose to populate:
-# 1 - "teams1" - if you want to track only 1 pipeline
-# 2 - "teams2" - if you want to track only 2 pipelines
-# 3 - "teams3" - if you want to track only 3 pipelines
-
-#######################################
-# Use this to track only 1 pipeline
-#######################################
-variable "teams1" {
-  description = "map"
-  default = {
-    "team-a" = {
-      title         = "fraud-cri-front"
-      owner         = "team-a@company.org"
-      samstackname1 = "fraud-cri-front"
-    }
-    "team-b" = {
-      title         = "ipv-cri-passport-front"
-      owner         = "team-b@company.org"
-      samstackname1 = "ipv-cri-passport-front"
-    }
-  }
-}
-
-#######################################
-# Use this to track only 2 pipelines
-#######################################
-variable "teams2" {
-  description = "map"
-  default = {
-    "team-a" = {
-      title         = "frontend backend-api"
-      owner         = "team-a@company.org"
-      samstackname1 = "frontend"
-      samstackname2 = "backend-api"
-    }
-    "team-b" = {
-      title         = "check-hmrc-cri-api check-hmrc-cri-front"
-      owner         = "team-b@company.org"
-      samstackname1 = "check-hmrc-cri-api"
-      samstackname2 = "check-hmrc-cri-front"
-    }
-    "team-c" = {
-      title         = "core-front core-back"
-      owner         = "team-c@company.org"
-      samstackname1 = "core-front"
-      samstackname2 = "core-back"
-    }
-    "team-d" = {
-      title         = "ipv-cri-passport-api ipv-cri-passport-front"
-      owner         = "team-d@company.org"
-      samstackname1 = "ipv-cri-passport-api"
-      samstackname2 = "ipv-cri-passport-front"
-    }
-    "team-e" = {
-      title         = "passport-api passport-front"
-      owner         = "team-d@company.org"
-      samstackname1 = "passport-api"
-      samstackname2 = "passport-front"
-    }
-  }
-}
-
-#######################################
-# Use this to track only 3 pipeline
-#######################################
-variable "teams3" {
-  description = "map"
-  default = {
-    "team-a" = {
-      title         = "frontend - backend-api - backend-api"
-      owner         = "team-a@company.org"
-      samstackname1 = "frontend"
-      samstackname2 = "backend-api"
-      samstackname3 = "backend-api"
-    }
-    "devplatform-demo-apps" = {
-      title         = "DevPlatform Demo SAM Applications"
-      owner         = "di-dev-platform-core@digital.cabinet-office.gov.uk"
-      samstackname1 = "demo-sam-app"
-      samstackname2 = "demo-sam-app2"
-      samstackname3 = "node-app"
-    }
-  }
-}
+# There are 3 template csv files you can choose to populate:
+# 1 - "template1" - if you want to track only 1 pipeline
+# 2 - "template2" - if you want to track only 2 pipelines
+# 3 - "template3" - if you want to track only 3 pipelines
 
 #######################################
 # 1 Secure Pipelines on the Dashboard
 #######################################
 resource "dynatrace_json_dashboard" "Team-DORA-Dashboards1" {
-  for_each = var.teams1
+  for_each = {
+    for f in csvdecode(file("./dashboards/dev-platform/template1.csv")) :
+    f.team => f
+  }
 
   contents = templatefile("./dashboards/dev-platform/TEMPLATE1_dashboard.json", {
-    title         = each.value.title
-    owner         = each.value.owner
+    title         = each.value.samstackname1
+    owner         = each.value.email
     samstackname1 = each.value.samstackname1
   })
 }
@@ -102,11 +24,14 @@ resource "dynatrace_json_dashboard" "Team-DORA-Dashboards1" {
 # 2 Secure Pipelines on the Dashboard
 #######################################
 resource "dynatrace_json_dashboard" "Team-DORA-Dashboards2" {
-  for_each = var.teams2
+  for_each = {
+    for f in csvdecode(file("./dashboards/dev-platform/template2.csv")) :
+    f.team => f
+  }
 
   contents = templatefile("./dashboards/dev-platform/TEMPLATE2_dashboard.json", {
-    title         = each.value.title
-    owner         = each.value.owner
+    title         = "${each.value.samstackname1} - ${each.value.samstackname2}"
+    owner         = each.value.email
     samstackname1 = each.value.samstackname1
     samstackname2 = each.value.samstackname2
   })
@@ -116,11 +41,14 @@ resource "dynatrace_json_dashboard" "Team-DORA-Dashboards2" {
 # 3 Secure Pipelines on the Dashboard
 #######################################
 resource "dynatrace_json_dashboard" "Team-DORA-Dashboards3" {
-  for_each = var.teams3
+  for_each = {
+    for f in csvdecode(file("./dashboards/dev-platform/template3.csv")) :
+    f.team => f
+  }
 
   contents = templatefile("./dashboards/dev-platform/TEMPLATE3_dashboard.json", {
-    title         = each.value.title
-    owner         = each.value.owner
+    title         = "${each.value.samstackname1} - ${each.value.samstackname2} - ${each.value.samstackname3}"
+    owner         = each.value.email
     samstackname1 = each.value.samstackname1
     samstackname2 = each.value.samstackname2
     samstackname3 = each.value.samstackname3
@@ -128,7 +56,10 @@ resource "dynatrace_json_dashboard" "Team-DORA-Dashboards3" {
 }
 
 resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards1" {
-  for_each = var.teams1
+  for_each = {
+    for f in csvdecode(file("./dashboards/dev-platform/template1.csv")) :
+    f.team => f
+  }
 
   dashboard_id = dynatrace_json_dashboard.Team-DORA-Dashboards1[each.key].id
   enabled      = true
@@ -146,7 +77,10 @@ resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards1" {
 }
 
 resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards2" {
-  for_each = var.teams2
+  for_each = {
+    for f in csvdecode(file("./dashboards/dev-platform/template2.csv")) :
+    f.team => f
+  }
 
   dashboard_id = dynatrace_json_dashboard.Team-DORA-Dashboards2[each.key].id
   enabled      = true
@@ -164,7 +98,10 @@ resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards2" {
 }
 
 resource "dynatrace_dashboard_sharing" "Team-DORA-Dashboards3" {
-  for_each = var.teams3
+  for_each = {
+    for f in csvdecode(file("./dashboards/dev-platform/template3.csv")) :
+    f.team => f
+  }
 
   dashboard_id = dynatrace_json_dashboard.Team-DORA-Dashboards3[each.key].id
   enabled      = true

--- a/dashboards/dev-platform/TEMPLATE1_dashboard.json
+++ b/dashboards/dev-platform/TEMPLATE1_dashboard.json
@@ -3,7 +3,7 @@
       "configurationVersions": [
         7
       ],
-      "clusterVersion": "1.291.99.20240515-061005"
+      "clusterVersion": "1.292.40.20240522-160528"
     },
     "dashboardMetadata": {
       "name": "DORA - ${title}",
@@ -160,8 +160,8 @@
           "resolution": ""
         },
         "metricExpressions": [
-          "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname1}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
-          "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname1}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
+          "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
+          "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
         ]
       },
       {
@@ -256,8 +256,8 @@
           "resolution": ""
         },
         "metricExpressions": [
-          "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
-          "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
+          "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
+          "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
         ]
       },
       {
@@ -351,8 +351,8 @@
           "resolution": ""
         },
         "metricExpressions": [
-          "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
-          "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
+          "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
+          "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
         ]
       },
       {
@@ -397,7 +397,7 @@
               "pipeline-version",
               "environment"
             ],
-            "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(\"build-success\",\"1\"))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",descending))",
+            "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",ascending))",
             "rate": "NONE",
             "enabled": true
           }
@@ -468,7 +468,7 @@
           "resolution": ""
         },
         "metricExpressions": [
-          "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(build-success,\"1\"))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,descending))):names"
+          "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,ascending))):names"
         ]
       },
       {

--- a/dashboards/dev-platform/TEMPLATE2_dashboard.json
+++ b/dashboards/dev-platform/TEMPLATE2_dashboard.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.291.99.20240515-061005"
+    "clusterVersion": "1.292.40.20240522-160528"
   },
   "dashboardMetadata": {
     "name": "DORA - ${title}",
@@ -253,8 +253,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname1}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
-        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname1}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
+        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
+        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
       ]
     },
     {
@@ -349,8 +349,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
-        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
+        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
+        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
       ]
     },
     {
@@ -445,8 +445,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
-        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
+        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
+        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
       ]
     },
     {
@@ -540,8 +540,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
-        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
+        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
       ]
     },
     {
@@ -635,8 +635,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
-        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
+        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
       ]
     },
     {
@@ -681,7 +681,7 @@
             "pipeline-version",
             "environment"
           ],
-          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(\"build-success\",\"1\"))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",descending))",
+          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",ascending))",
           "rate": "NONE",
           "enabled": true
         }
@@ -746,7 +746,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(build-success,\"1\"))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,descending))):names"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,ascending))):names"
       ]
     },
     {
@@ -777,7 +777,7 @@
             "pipeline-version",
             "environment"
           ],
-          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(\"build-success\",\"1\"))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",descending))",
+          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",ascending))",
           "rate": "NONE",
           "enabled": true
         }
@@ -848,7 +848,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(build-success,\"1\"))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,descending))):names"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,ascending))):names"
       ]
     },
     {

--- a/dashboards/dev-platform/TEMPLATE3_dashboard.json
+++ b/dashboards/dev-platform/TEMPLATE3_dashboard.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.291.99.20240515-061005"
+    "clusterVersion": "1.292.40.20240522-160528"
   },
   "dashboardMetadata": {
     "name": "DORA - ${title}",
@@ -160,8 +160,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname2}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
-        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname2}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
+        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
+        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
       ]
     },
     {
@@ -253,8 +253,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname1}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
-        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname1}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
+        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
+        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
       ]
     },
     {
@@ -350,8 +350,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname3}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
-        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,${samstackname3}),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
+        "resolution=Inf&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending)))):names",
+        "resolution=null&((devplatform.sam-pipelines.deployment:filter(and(eq(environment,build),eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy))):splitBy():count:sort(value(avg,descending))))"
       ]
     },
     {
@@ -446,8 +446,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
-        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
+        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
+        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
       ]
     },
     {
@@ -542,8 +542,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
-        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build)))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
+        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
+        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
       ]
     },
     {
@@ -638,8 +638,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname3}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname3}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname3}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
-        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname3}),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname3}),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname3}),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
+        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname3}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100):names",
+        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy),eq(environment,build))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname3}\"),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy),eq(environment,build))):splitBy():count))*100)"
       ]
     },
     {
@@ -733,8 +733,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
-        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
+        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
       ]
     },
     {
@@ -828,8 +828,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
-        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
+        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
       ]
     },
     {
@@ -926,8 +926,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname3}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
-        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,${samstackname3}),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second)):names",
+        "resolution=null&(devplatform.sam-pipelines.deployment.stage.timesincemerge:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy),eq(environment,production))):splitBy():sort(value(auto,descending)):avg:setUnit(Second))"
       ]
     },
     {
@@ -972,7 +972,7 @@
             "pipeline-version",
             "environment"
           ],
-          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy),eq(\"build-success\",\"1\"))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",descending))",
+          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",ascending))",
           "rate": "NONE",
           "enabled": true
         }
@@ -1037,7 +1037,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname2}),eq(stage,deploy),eq(build-success,\"1\"))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,descending))):names"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname2}\"),eq(stage,deploy))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,ascending))):names"
       ]
     },
     {
@@ -1068,7 +1068,7 @@
             "pipeline-version",
             "environment"
           ],
-          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy),eq(\"build-success\",\"1\"))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",descending))",
+          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",ascending))",
           "rate": "NONE",
           "enabled": true
         }
@@ -1133,7 +1133,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname3}),eq(stage,deploy),eq(build-success,\"1\"))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,descending))):names"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname3}\"),eq(stage,deploy))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,ascending))):names"
       ]
     },
     {
@@ -1164,7 +1164,7 @@
             "pipeline-version",
             "environment"
           ],
-          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy),eq(\"build-success\",\"1\"))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",descending))",
+          "metricSelector": "devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy(\"pipeline-version\",\"environment\"):count:sort(dimension(\"pipeline-version\",ascending))",
           "rate": "NONE",
           "enabled": true
         }
@@ -1235,7 +1235,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,${samstackname1}),eq(stage,deploy),eq(build-success,\"1\"))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,descending))):names"
+        "resolution=Inf&(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${samstackname1}\"),eq(stage,deploy))):splitBy(pipeline-version,environment):count:sort(dimension(pipeline-version,ascending))):names"
       ]
     },
     {

--- a/dashboards/dev-platform/pipelines-list.csv
+++ b/dashboards/dev-platform/pipelines-list.csv
@@ -1,0 +1,3 @@
+team,email,samstackname1
+CRI-Lime,cri-lime-team@digital.cabinet-office.gov.uk,ipv-cri-uk-passport-api
+CRI-Lime,cri-lime-team@digital.cabinet-office.gov.uk,ipv-cri-passport-front

--- a/dashboards/dev-platform/template1.csv
+++ b/dashboards/dev-platform/template1.csv
@@ -1,3 +1,0 @@
-team,email,samstackname1
-team-a,team-a@company.org,fraud-cri-front
-team-b,team-b@company.org,ipv-cri-passport-front

--- a/dashboards/dev-platform/template1.csv
+++ b/dashboards/dev-platform/template1.csv
@@ -1,0 +1,3 @@
+team,email,samstackname1
+team-a,team-a@company.org,fraud-cri-front
+team-b,team-b@company.org,ipv-cri-passport-front

--- a/dashboards/dev-platform/template2.csv
+++ b/dashboards/dev-platform/template2.csv
@@ -1,6 +1,2 @@
 team,email,samstackname1,samstackname2
-team-a,team-a@company.org,frontend,backend-api
-team-b,team-b@company.org,check-hmrc-cri-api,check-hmrc-cri-front
-team-c,team-c@company.org,core-front,core-back
-team-d,team-d@company.org,ipv-cri-passport-api,ipv-cri-passport-front
-team-e,team-d@company.org,passport-api,passport-front
+CRI-Lime,cri-lime-team@digital.cabinet-office.gov.uk,ipv-cri-uk-passport-api,ipv-cri-passport-front

--- a/dashboards/dev-platform/template2.csv
+++ b/dashboards/dev-platform/template2.csv
@@ -1,0 +1,6 @@
+team,email,samstackname1,samstackname2
+team-a,team-a@company.org,frontend,backend-api
+team-b,team-b@company.org,check-hmrc-cri-api,check-hmrc-cri-front
+team-c,team-c@company.org,core-front,core-back
+team-d,team-d@company.org,ipv-cri-passport-api,ipv-cri-passport-front
+team-e,team-d@company.org,passport-api,passport-front

--- a/dashboards/dev-platform/template3.csv
+++ b/dashboards/dev-platform/template3.csv
@@ -1,0 +1,3 @@
+team,email,samstackname1,samstackname2,samstackname3
+team-a,team-a@company.org,frontend,backend-api,backend-api
+devplatform-demo-apps,di-dev-platform-core@digital.cabinet-office.gov.uk,demo-sam-app,demo-sam-app2,node-app

--- a/dashboards/dev-platform/template3.csv
+++ b/dashboards/dev-platform/template3.csv
@@ -1,3 +1,2 @@
 team,email,samstackname1,samstackname2,samstackname3
-team-a,team-a@company.org,frontend,backend-api,backend-api
-devplatform-demo-apps,di-dev-platform-core@digital.cabinet-office.gov.uk,demo-sam-app,demo-sam-app2,node-app
+devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,demo-sam-app,demo-sam-app2,node-app


### PR DESCRIPTION
# Description:

Team specific pipeline DORA dashboards: 
1. show pipeline versions from failed deployments, previously the queries were filtered only to collect successful deployments
2. pipeline versions appear in ascending order, highlighting older versions first. 

Updates to observability-configuration/dashboards-dora.tf
1. Variables teams1, team2, team3 with default values replaced with csv files
3. Updated instructions to reflect the above changes

## Ticket number:
[PSREDEV-800]

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
**Cannot be fully tested unless the PR is merged. Terraform plans on the pre-merge checks look good.**

- [ ] Documentation added (link) Comment:


[PSREDEV-800]: https://govukverify.atlassian.net/browse/PSREDEV-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ