### PR TITLE
LS-2134 Fixed critical conformance pack filter

### DIFF
--- a/dashboards/capacity/critical-conformance.json
+++ b/dashboards/capacity/critical-conformance.json
@@ -6,17 +6,45 @@
     "clusterVersion": "1.293.111.20240607-142608"
   },
   "dashboardMetadata": {
-    "name": "CRITICAL Conformance Pack Reviews",
+    "name": "Critical Conformance Pack Reviews",
     "shared": false,
+    "owner": "andrew.loughran@digital.cabinet-office.gov.uk",
     "tags": [
-      "Security",
+      "Critical",
       "Conformance"
     ],
-    "owner": "andrew.loughran@digital.cabinet-office.gov.uk",
     "popularity": 1,
     "hasConsistentColors": false
   },
   "tiles": [
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 722,
+        "left": 0,
+        "width": 1140,
+        "height": 152
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Lowest Compliance\n\nThe same data above is rendered below, but ordered by the lowest-compliant account first. \n\nIf you are top of this list please make sure you've reviewed your account and worked out which rules you are out of compliance with."
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 1140,
+        "height": 152
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Critical Conformance\n\nThe tile below shows the account's compliance with conformance packs.  100% implies there is no problem, but less than that and you'll need to identify the account number by hovering over the tile, and login to review AWS Config to see which resources are not compliant with the conformance pack."
+    },
     {
       "name": "CriticalConformance",
       "tileType": "DATA_EXPLORER",
@@ -39,7 +67,7 @@
             "aws.account.id",
             "conformancepack"
           ],
-          "metricSelector": "cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",\"conformancepack\"):sort(value(auto,descending))\n\n\n",
+          "metricSelector": "cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",\"conformancepack\"):sort(value(auto,descending)):filter(contains(\"conformancepack\",\"Critical\"))\n\n\n\n",
           "rate": "NONE",
           "enabled": true
         }
@@ -111,7 +139,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",conformancepack):sort(value(auto,descending))):names"
+        "resolution=Inf&(cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",conformancepack):sort(value(auto,descending)):filter(contains(conformancepack,Critical))):names"
       ]
     },
     {
@@ -122,7 +150,7 @@
         "top": 874,
         "left": 0,
         "width": 1140,
-        "height": 760
+        "height": 2584
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -136,7 +164,7 @@
             "aws.account.id",
             "conformancepack"
           ],
-          "metricSelector": "cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",\"conformancepack\"):sort(value(auto,ascending))\n\n",
+          "metricSelector": "cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",\"conformancepack\"):sort(value(auto,ascending)):filter(contains(\"conformancepack\",\"Critical\"))\n\n\n",
           "rate": "NONE",
           "enabled": true
         }
@@ -195,36 +223,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",conformancepack):sort(value(auto,ascending))):limit(100):names"
+        "resolution=Inf&(cloud.aws.config.complianceScoreByAccountIdConformancePackRegion:splitBy(\"aws.account.id\",conformancepack):sort(value(auto,ascending)):filter(contains(conformancepack,Critical))):limit(100):names"
       ]
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 722,
-        "left": 0,
-        "width": 1140,
-        "height": 152
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## Lowest Compliance\n\nThe same data above is rendered below, but ordered by the lowest-compliant account first. \n\nIf you are top of this list please make sure you've reviewed your account and worked out which rules you are out of compliance with."
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 0,
-        "left": 0,
-        "width": 1140,
-        "height": 152
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## Critical Conformance\n\nThe tile below shows the account's compliance with conformance packs.  100% implies there is no problem, but less than that and you'll need to identify the account number by hovering over the tile, and login to review AWS Config to see which resources are not compliant with the conformance pack."
     }
   ]
 }


### PR DESCRIPTION
# Description:

Fixed the problem with CRITICAL not filtering just on the Critical packs.

## Ticket number:
[LS-2134]

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:


[LS-2134]: https://govukverify.atlassian.net/browse/LS-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ