### PR TITLE
PSREO-240 add ignore_missing_prereq_for_this_step to failure detection

### DIFF
--- a/failure_detection.tf
+++ b/failure_detection.tf
@@ -87,3 +87,48 @@ resource "dynatrace_failure_detection_rules" "ignore_invalid_csrf_token" {
     }
   }
 }
+
+resource "dynatrace_failure_detection_parameters" "ignore_missing_prereq_for_this_step" {
+  name = "ignore-missing-prereq-for-this-step"
+
+  broken_links {
+    http_404_not_found_failures = false
+  }
+
+  http_response_codes {
+    client_side_errors                        = "400-599"
+    server_side_errors                        = "500-599"
+    fail_on_missing_response_code_client_side = false
+    fail_on_missing_response_code_server_side = false
+  }
+
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = false
+
+    ignored_exceptions {
+      custom_handled_exception {
+        message_pattern = "Missing prereq for this step"
+      }
+    }
+  }
+}
+
+resource "dynatrace_failure_detection_rules" "ignore_missing_prereq_for_this_step" {
+  name         = "ignore-missing-prereq-for-this-step"
+  enabled      = true
+  parameter_id = dynatrace_failure_detection_parameters.ignore_missing_prereq_for_this_step.id
+
+  conditions {
+    condition {
+      attribute = "SERVICE_TYPE"
+      predicate {
+        predicate_type = "SERVICE_TYPE_EQUALS"
+        service_type = [
+          "WebRequest",
+          "WebService"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description:

Add ignore parameters and rules to Dynatrace failure detection for "Missing prereq for this step" error.

## Ticket number:
[PSREO-240]



[PSREO-240]: https://govukverify.atlassian.net/browse/PSREO-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ