### PR TITLE
IPS-800: Update the markdown links on  the core and KIWI dashboards

### DIFF
--- a/dashboards/core/services.json
+++ b/dashboards/core/services.json
@@ -27,7 +27,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [Core Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=39bd8868-97d4-4abe-a27d-ec714c0b687c)"
+      "markdown": "## [Core Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=510508e0-e354-41e2-a6af-54bf4bc12663)"
     },
     {
       "name": "Markdown",
@@ -41,7 +41,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [Core Api Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=06510367-6b89-4c04-88d6-cce9f917aee8)"
+      "markdown": "## [Core Api Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=f172ea33-bf27-45a0-92de-0d00df2e5dbf)"
     },
     {
       "name": "Markdown",
@@ -55,7 +55,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [Core SQS Metrics](https://bhe21058.live.dynatrace.com/#edit;gtf=-30d%20to%20now;gf=all;id=ab153953-3358-42aa-8d27-4704da58fdc4)"
+      "markdown": "## [Core SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=fcd5710b-adb0-45e6-99e5-4aca6f269404)"
     },
     {
       "name": "Markdown",
@@ -69,7 +69,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [Core Cloudfront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=2c90b29e-9153-4c9f-b74a-7292082264e4)"
+      "markdown": "## [Core Cloudfront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=c3b31f58-6bed-4d9e-b252-83e94db2c7a4)"
     },
     {
       "name": "CPU Utilisation by Service",

--- a/dashboards/kiwi/apigw-metrics.json
+++ b/dashboards/kiwi/apigw-metrics.json
@@ -24,45 +24,59 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## F2F CRI Api Gateway - [Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-BF50997803C3D006;gtf=-2h;gf=all)"
+      "markdown": "## F2F CRI Api Gateway - [Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-BF50997803C3D006;gtf=-30d%20to%20now;gf=all)"
     },
     {
       "name": "Markdown",
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 418,
+        "top": 1102,
         "left": 0,
         "width": 608,
         "height": 38
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## CIC CRI Api Gateway - [Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-51DBAFF9F7C83607;gtf=-2h;gf=all)"
+      "markdown": "## CIC CRI Api Gateway - [Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-51DBAFF9F7C83607;gtf=-30d%20to%20now;gf=all)"
     },
     {
       "name": "Markdown",
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 836,
+        "top": 2166,
         "left": 0,
         "width": 608,
         "height": 38
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## IPVReturn Api Gateway - [Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-4A3E7697358DD24D;gtf=-2h;gf=all)"
+      "markdown": "## IPVReturn Api Gateway - [Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-4A3E7697358DD24D;gtf=-30d%20to%20now;gf=all)"
     },
     {
-      "name": "Frontend API Requests and Error",
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 3230,
+        "left": 0,
+        "width": 608,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## BAV CRI Api Gateway - [Dashboard]()"
+    },
+    {
+      "name": "Frontend Requests",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 38,
-        "left": 760,
-        "width": 722,
-        "height": 342
+        "top": 3268,
+        "left": 1254,
+        "width": 1026,
+        "height": 684
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -73,9 +87,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.service"
+            "apiid"
           ],
-          "metricSelector": "builtin:service.requestCount.total:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-ipv-cri-f2f-front~\")\")))))",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegionStage:filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
@@ -84,9 +98,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.service"
+            "apiid"
           ],
-          "metricSelector": "builtin:service.errors.fourxx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-ipv-cri-f2f-front~\")\")))))",
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
@@ -95,9 +109,9 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "dt.entity.service"
+            "apiid"
           ],
-          "metricSelector": "builtin:service.errors.fivexx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-ipv-cri-f2f-front~\")\")))))",
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
@@ -132,6 +146,2578 @@
             "valueFormat": "auto",
             "properties": {
               "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            },
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegionStage:filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend API Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 380,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 380,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 5xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 722,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 5xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 722,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 722,
+        "left": 1254,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():count:sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():count:sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend 5xx and Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 722,
+        "left": 1938,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Backend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1140,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1140,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1482,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1482,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1824,
+        "left": 1254,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1824,
+        "left": 1596,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend 5xx and Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1824,
+        "left": 1938,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(count,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(count,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(count,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend 5xx and Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 1938,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(count,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(count,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(count,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Backend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2204,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "TURQUOISE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2546,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend API Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2204,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "TURQUOISE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2546,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 5xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):sum:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 1254,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,\"zfqk0q86n9\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,zfqk0q86n9)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,zfqk0q86n9)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 1596,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,\"zfqk0q86n9\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,zfqk0q86n9)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,zfqk0q86n9)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend API Requests and Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2204,
+        "left": 1254,
+        "width": 1026,
+        "height": 684
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,\"zfqk0q86n9\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,\"zfqk0q86n9\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,\"zfqk0q86n9\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "PURPLE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            },
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,zfqk0q86n9)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,zfqk0q86n9)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"821078365651\")),or(eq(apiid,zfqk0q86n9)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1140,
+        "left": 1254,
+        "width": 1026,
+        "height": 684
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            },
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"270790667266\")),or(eq(apiid,y55apwo050)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 1254,
+        "width": 1026,
+        "height": 684
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
               "seriesType": "STACKED_COLUMN"
             },
             "seriesOverrides": []
@@ -204,17 +2790,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:service.requestCount.total:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-ipv-cri-f2f-front~\")\")))))):limit(100):names,(builtin:service.errors.fourxx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-ipv-cri-f2f-front~\")\")))))):limit(100):names,(builtin:service.errors.fivexx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-ipv-cri-f2f-front~\")\")))))):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():count:sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "Frontend API Requests and Error",
+      "name": "Frontend 4xx Error",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 456,
-        "left": 760,
-        "width": 722,
+        "top": 722,
+        "left": 1596,
+        "width": 342,
         "height": 342
       },
       "tileFilter": {},
@@ -222,53 +2808,19 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.service"
-          ],
-          "metricSelector": "builtin:service.requestCount.total:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-cic-front~\")\")))))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
           "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.service"
-          ],
-          "metricSelector": "builtin:service.errors.fourxx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-cic-front~\")\")))))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.service"
-          ],
-          "metricSelector": "builtin:service.errors.fivexx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-cic-front~\")\")))))",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,8odghv7ewk)),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
-        "type": "STACKED_COLUMN",
+        "type": "SINGLE_VALUE",
         "global": {},
         "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "ROYALBLUE",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
           {
             "matcher": "B:",
             "unitTransform": "auto",
@@ -278,51 +2830,21 @@
               "seriesType": "STACKED_COLUMN"
             },
             "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
           }
         ],
         "axes": {
           "xAxis": {
-            "displayName": "",
             "visible": true
           },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
+          "yAxes": []
         },
         "heatmapSettings": {
           "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
         },
         "thresholds": [
           {
@@ -357,170 +2879,18 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:service.requestCount.total:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-cic-front~\")\")))))):limit(100):names,(builtin:service.errors.fourxx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-cic-front~\")\")))))):limit(100):names,(builtin:service.errors.fivexx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"di-cic-front~\")\")))))):limit(100):names"
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"377086294028\")),or(eq(apiid,\"8odghv7ewk\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():auto:sort(value(auto,descending)):limit(20))"
       ]
     },
     {
-      "name": "Frontend API Requests and Error",
+      "name": "Backend 5xx Error",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 874,
-        "left": 760,
-        "width": 722,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.service"
-          ],
-          "metricSelector": "builtin:service.requestCount.total:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"node_project~\")\")))))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.service"
-          ],
-          "metricSelector": "builtin:service.errors.fourxx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"node_project~\")\")))))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.service"
-          ],
-          "metricSelector": "builtin:service.errors.fivexx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"node_project~\")\")))))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "ROYALBLUE",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(builtin:service.requestCount.total:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"node_project~\")\")))))):limit(100):names,(builtin:service.errors.fourxx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"node_project~\")\")))))):limit(100):names,(builtin:service.errors.fivexx.rate:filter(and(or(in(\"dt.entity.service\",entitySelector(\"type(service),entityName.equals(~\"node_project~\")\")))))):limit(100):names"
-      ]
-    },
-    {
-      "name": "Backend API Requests and Error",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 38,
+        "top": 2888,
         "left": 0,
-        "width": 722,
+        "width": 874,
         "height": 342
       },
       "tileFilter": {},
@@ -528,35 +2898,13 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
           "id": "C",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "apiname"
+            "resource"
           ],
-          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):auto:sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
@@ -565,312 +2913,6 @@
         "type": "STACKED_COLUMN",
         "global": {},
         "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "TURQUOISE",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names,(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"f2f-cri-api - F2F Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names"
-      ]
-    },
-    {
-      "name": "Backend API Requests and Error",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 456,
-        "left": 0,
-        "width": 722,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\n\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "TURQUOISE",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\n\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names,(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names"
-      ]
-    },
-    {
-      "name": "Backend API Requests and Error",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 874,
-        "left": 0,
-        "width": 722,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")))):splitBy(apiname):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          },
           {
             "matcher": "C:",
             "unitTransform": "auto",
@@ -895,8 +2937,6 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B",
                 "C"
               ],
               "defaultAxis": true
@@ -939,7 +2979,1023 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names,(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")))):splitBy(apiname):sum:sort(value(sum,descending))):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"ipvreturn-api - IPVR API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):auto:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3268,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):count:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3268,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):count:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3610,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):auto:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):auto:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 5xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1824,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):auto:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):auto:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 5xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1824,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):auto:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"cic-cri-api - CIC Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):auto:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 5xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3952,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):auto:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):auto:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 5xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3952,
+        "left": 874,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):auto:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):auto:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3610,
+        "left": 0,
+        "width": 874,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(\"resource\"):auto:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy(resource):auto:sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3952,
+        "left": 1254,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegionStage:filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiIdRegionStage:filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegionStage:filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend 4xx Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3952,
+        "left": 1596,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "Frontend 5xx and Error",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3952,
+        "left": 1938,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(or(eq(\"aws.account.id\",\"096369912800\")),or(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20))"
       ]
     }
   ]

--- a/dashboards/kiwi/bav-cri.json
+++ b/dashboards/kiwi/bav-cri.json
@@ -25,7 +25,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=589dc88d-a778-4450-89e1-e7ef2c530f78)\n"
+      "markdown": "## [BAV ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4da27632-b4e2-4abe-bb50-c2c8c1270446)\n"
     },
     {
       "name": "Markdown",
@@ -39,7 +39,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=ca31f3f1-f255-42b8-a77d-debc0068ec23)\n"
+      "markdown": "## [BAV API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=e64d7aae-f0b1-477e-9a95-a8d8a978f16e)\n"
     },
     {
       "name": "Markdown",
@@ -53,7 +53,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4681c3a1-33b8-476a-bcbe-53aee7ad120b)"
+      "markdown": "## [BAV Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=c12a984b-f5ea-4c25-9606-b6c9f15523b7)"
     },
     {
       "name": "BAV Lambda Errors",
@@ -478,7 +478,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV CloudFront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4c3b573b-e6a8-4be2-acd8-0bba24e78566)\n"
+      "markdown": "## [BAV CloudFront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=12d040b2-3461-4270-83aa-a3e8654fdc04)\n"
     },
     {
       "name": "Backend Requests",
@@ -2007,7 +2007,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV SQS Metrics](https://bhe21058.live.dynatrace.com/#edit;gtf=-30d%20to%20now;gf=all;id=ff8fb43d-2e04-48e8-92a5-a58fdc5793e8;tileId=30)\n"
+      "markdown": "## [BAV SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=8cd69e4a-5911-47bd-87bb-7a8343c54189)\n"
     }
   ]
 }

--- a/dashboards/kiwi/cic-cri.json
+++ b/dashboards/kiwi/cic-cri.json
@@ -391,7 +391,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [CIC ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=589dc88d-a778-4450-89e1-e7ef2c530f78)\n"
+      "markdown": "## [CIC ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4da27632-b4e2-4abe-bb50-c2c8c1270446)\n"
     },
     {
       "name": "Markdown",
@@ -405,7 +405,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [CIC API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=ca31f3f1-f255-42b8-a77d-debc0068ec23)\n"
+      "markdown": "## [CIC API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=e64d7aae-f0b1-477e-9a95-a8d8a978f16e)\n"
     },
     {
       "name": "Markdown",
@@ -419,7 +419,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [CIC Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=f55b6535-4716-4b8c-ae70-b32a151e6942)\n"
+      "markdown": "## [CIC Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=fd61cd4f-a63c-40ff-915f-9e36e3a41a58)\n"
     },
     {
       "name": "Markdown",
@@ -433,7 +433,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [CIC CloudFront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4c3b573b-e6a8-4be2-acd8-0bba24e78566)\n"
+      "markdown": "## [CIC CloudFront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=12d040b2-3461-4270-83aa-a3e8654fdc04)\n"
     },
     {
       "name": "Backend Requests",
@@ -1962,7 +1962,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [CIC SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;id=ff8fb43d-2e04-48e8-92a5-a58fdc5793e8;gtf=-30d%20to%20now;gf=all)\n"
+      "markdown": "## [CIC SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=8cd69e4a-5911-47bd-87bb-7a8343c54189)\n"
     }
   ]
 }

--- a/dashboards/kiwi/f2f-cri.json
+++ b/dashboards/kiwi/f2f-cri.json
@@ -421,7 +421,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [F2F ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=589dc88d-a778-4450-89e1-e7ef2c530f78)\n"
+      "markdown": "## [F2F ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4da27632-b4e2-4abe-bb50-c2c8c1270446)\n"
     },
     {
       "name": "Markdown",
@@ -435,7 +435,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [F2F API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=ca31f3f1-f255-42b8-a77d-debc0068ec23)\n"
+      "markdown": "## [F2F API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=e64d7aae-f0b1-477e-9a95-a8d8a978f16e)\n"
     },
     {
       "name": "Markdown",
@@ -449,7 +449,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [F2F Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=fbdcd6e2-f5f5-40d0-8aaa-2d91f5c9d636)"
+      "markdown": "## [F2F Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=dfc2880a-c6a7-4422-8480-182b96993b2b)"
     },
     {
       "name": "Markdown",
@@ -463,7 +463,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [F2F CloudFront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4c3b573b-e6a8-4be2-acd8-0bba24e78566)\n"
+      "markdown": "## [F2F CloudFront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=12d040b2-3461-4270-83aa-a3e8654fdc04)\n"
     },
     {
       "name": "CPU Utilisation",
@@ -2109,7 +2109,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [F2F SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=f13aaf48-0be0-48ec-af1c-b35a532ec496)\n"
+      "markdown": "## [F2F SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=8cd69e4a-5911-47bd-87bb-7a8343c54189)\n"
     }
   ]
 }

--- a/dashboards/kiwi/ipr-cri.json
+++ b/dashboards/kiwi/ipr-cri.json
@@ -338,7 +338,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVReturn Lambda Matrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=09d2e6ed-cda0-410c-a6f3-4c5c331a1bb3)\n"
+      "markdown": "## [IPVReturn Lambda Matrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=97de5ccd-784d-4a19-9950-9fab7594d803)\n"
     },
     {
       "name": "Markdown",
@@ -352,7 +352,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVReturn ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=bea5feb5-c1a2-4892-a7c1-880ada11a724)\n"
+      "markdown": "## [IPVReturn ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4da27632-b4e2-4abe-bb50-c2c8c1270446)\n"
     },
     {
       "name": "Markdown",
@@ -366,7 +366,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVReturn API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=ca31f3f1-f255-42b8-a77d-debc0068ec23)\n"
+      "markdown": "## [IPVReturn API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=e64d7aae-f0b1-477e-9a95-a8d8a978f16e)\n"
     },
     {
       "name": "Markdown",
@@ -380,7 +380,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVReturn Cloudfront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4c3b573b-e6a8-4be2-acd8-0bba24e78566)\n"
+      "markdown": "## [IPVReturn Cloudfront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=12d040b2-3461-4270-83aa-a3e8654fdc04)\n"
     },
     {
       "name": "Backend Requests",
@@ -1909,7 +1909,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVReturn Cloudfront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4c3b573b-e6a8-4be2-acd8-0bba24e78566)\n"
+      "markdown": "## [IPVReturn SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=8cd69e4a-5911-47bd-87bb-7a8343c54189)\n"
     }
   ]
 }

--- a/dashboards/kiwi/services.json
+++ b/dashboards/kiwi/services.json
@@ -1081,7 +1081,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV CRI Dashboard](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=3cae3364-7aab-4b49-8b0b-c30a255374fa)\n"
+      "markdown": "## [BAV CRI Dashboard](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=dd09eb1f-6e28-42ac-bbf7-82ae57ce5710)\n"
     },
     {
       "name": "CPU Utilisation by Service",


### PR DESCRIPTION
# Description:
- Update the markdown links on the Core and KIWI dashboards. This will allow to delete the dev dashboards. 
## Ticket number:
[IPS-800]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[IPS-800]: https://govukverify.atlassian.net/browse/IPS-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ