### PR TITLE
LS-2196 Add dashboards for monitoring production stubs for IPV (Passport) load tests

### DIFF
--- a/dashboards.tf
+++ b/dashboards.tf
@@ -480,6 +480,37 @@ module "demo_node_app_build" {
   apigwid      = "dcbmiq3klk"
 }
 
+### Stub Scaling
+
+module "passport_stub_prod" {
+  count  = local.is_production ? 1 : 0 # Only create in production
+  source = "./dashboards/scaling/ecs_scaling"
+
+  service_name = "core-passport-stub-CoreStubCluster-NQ5KEj5sHd23"
+  apigwid      = "ekid21luu0"
+}
+
+module "dcmaw_stub_prod" {
+  count  = local.is_production ? 1 : 0 # Only create in production
+  source = "./dashboards/scaling/ecs_scaling"
+
+  service_name = "cri-dcmaw-stub-CriStubCluster-FHnsWcylw9xF"
+  apigwid      = "b8p08dkt2j"
+}
+
+module "orch_stub_prod" {
+  count  = local.is_production ? 1 : 0 # Only create in production
+  source = "./dashboards/scaling/ecs_scaling"
+
+  service_name = "orch-stub-OrchStubCluster-MX5ABExn4UBe"
+  apigwid      = "auybpw27y5"
+}
+
+
+
+
+
+
 ### DAP ###
 
 module "dap_dashboard" {

--- a/dashboards.tf
+++ b/dashboards.tf
@@ -506,6 +506,31 @@ module "orch_stub_prod" {
   apigwid      = "auybpw27y5"
 }
 
+module "address_stub_prod" {
+  count  = local.is_production ? 1 : 0 # Only create in production
+  source = "./dashboards/scaling/ecs_scaling"
+
+  service_name = "cri-address-stub-CriStubCluster-RurfVI7oqjP5"
+  apigwid      = "d0ky0q5yq2"
+}
+
+module "fraud_stub_prod" {
+  count  = local.is_production ? 1 : 0 # Only create in production
+  source = "./dashboards/scaling/ecs_scaling"
+
+  service_name = "cri-fraud-stub-CriStubCluster-Nlvogc90ip18"
+  apigwid      = "1pl6grmhn1"
+}
+
+module "kbv_stub_prod" {
+  count  = local.is_production ? 1 : 0 # Only create in production
+  source = "./dashboards/scaling/ecs_scaling"
+
+  service_name = "cri-experian-kbv-stub-CriStubCluster-El8h6wadGLXa"
+  apigwid      = "tt0fh9pg4h"
+}
+
+
 
 
 


### PR DESCRIPTION
# Description:

This adds six dashboards for the load test:

- orch
- dcmaw
- passport
- address
- fraud
- kbv

## Ticket number:
[LS-2196]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[LS-2196]: https://govukverify.atlassian.net/browse/LS-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ