### PR TITLE
OJ-2647: Updated Orange Address Dashboards to include Postcode Errors

### DIFF
--- a/dashboards/orange/address-cri.json
+++ b/dashboards/orange/address-cri.json
@@ -348,8 +348,7 @@
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
                 "nestedFilters": [],
-                "criteria": [
-                ]
+                "criteria": []
               },
               {
                 "filter": "apiname",
@@ -358,16 +357,17 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
               }
-            ]
+            ],
+            "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
@@ -445,8 +445,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
       ]
     },
     {
@@ -481,11 +481,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -573,7 +573,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -608,16 +608,17 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
               }
-            ]
+            ],
+            "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
@@ -699,7 +700,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -821,8 +822,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegionStage:filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
       ]
     },
     {
@@ -859,11 +860,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -943,8 +944,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
       ]
     },
     {
@@ -981,11 +982,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -1070,7 +1071,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -1865,8 +1866,7 @@
           ],
           "filterBy": {
             "filterOperator": "AND",
-            "nestedFilters": [
-            ],
+            "nestedFilters": [],
             "criteria": []
           },
           "rate": "NONE",
@@ -1882,8 +1882,7 @@
           ],
           "filterBy": {
             "filterOperator": "AND",
-            "nestedFilters": [
-            ],
+            "nestedFilters": [],
             "criteria": []
           },
           "rate": "NONE",
@@ -1981,7 +1980,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-address-api.authorization_sentByAccountIdRegionService:filter():splitBy(service):sum:sort(value(sum,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-address-api.no_authorization_codeByAccountIdRegionService:filter():splitBy(service):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-address-api.authorization_sentByAccountIdRegionService:splitBy(service):sum:sort(value(sum,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-address-api.no_authorization_codeByAccountIdRegionService:splitBy(service):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -2408,6 +2407,100 @@
       },
       "metricExpressions": [
         "resolution=Inf&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"common-cri-api~\")\")),in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):sort(value(auto,descending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "Postcode lookup errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 608,
+        "left": 1026,
+        "width": 456,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Postcode lookup errors",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.di-ipv-cri-address-api.postcode_lookup_errorByAccountIdRegionpostcode_lookup_error_messagepostcode_lookup_error_type",
+          "spaceAggregation": "SUM",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "postcode_lookup_error_type",
+            "postcode_lookup_error_message"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "nestedFilters": [],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TOP_LIST",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.di-ipv-cri-address-api.postcode_lookup_errorByAccountIdRegionpostcode_lookup_error_messagepostcode_lookup_error_type:splitBy(postcode_lookup_error_type,postcode_lookup_error_message):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     }
   ]

--- a/dashboards/orange/address-lambda-metrics.json
+++ b/dashboards/orange/address-lambda-metrics.json
@@ -15,7 +15,7 @@
     "popularity": 4,
     "hasConsistentColors": false
   },
-  "tiles": [
+ "tiles": [
     {
       "name": "Markdown",
       "tileType": "MARKDOWN",
@@ -823,7 +823,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contain(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contain(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -994,7 +994,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -3493,7 +3493,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -3664,7 +3664,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -3835,7 +3835,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-GetAddressesFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -4006,7 +4006,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contain(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contain(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -4223,7 +4223,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contain(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contain(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contain(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-IssueCredentialFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -4440,7 +4440,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -4611,7 +4611,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName(~\"address-cri-api-v1-PostcodeLookupFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -5290,7 +5290,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -5327,11 +5327,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5420,7 +5420,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -5485,11 +5485,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5568,7 +5568,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -5605,11 +5605,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5698,7 +5698,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,address-cri-api-v1-PublicAddressApi),eq(apiname,address-cri-api-v1-PrivateAddressApi)))):splitBy(resource):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -5816,8 +5816,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(builtin:tech.generic.cpu.groupTotalTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName.equals(~\"address-cri-front~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(builtin:tech.generic.cpu.groupTotalTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName.equals(~\"address-cri-front~\")\"))))):splitBy():sort(value(auto,descending)):limit(20))"
+        "resolution=Inf&(builtin:tech.generic.cpu.groupTotalTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName(~\"address-cri-front~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
+        "resolution=null&(builtin:tech.generic.cpu.groupTotalTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName(~\"address-cri-front~\")\"))))):splitBy():sort(value(auto,descending)):limit(20))"
       ]
     },
     {
@@ -5977,8 +5977,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(builtin:tech.generic.cpu.groupSuspensionTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName.equals(~\"address-cri-front~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(builtin:tech.generic.cpu.groupSuspensionTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName.equals(~\"address-cri-front~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20))"
+        "resolution=Inf&(builtin:tech.generic.cpu.groupSuspensionTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName(~\"address-cri-front~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
+        "resolution=null&(builtin:tech.generic.cpu.groupSuspensionTime:filter(and(or(in(\"dt.entity.process_group\",entitySelector(\"type(process_group),entityName(~\"address-cri-front~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20))"
       ]
     },
     {
@@ -6120,6 +6120,236 @@
       },
       "metricExpressions": [
         "resolution=Inf&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):sum:sort(value(sum,descending)):limit(20)):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):avg:sort(value(avg,descending)):limit(20)):names,(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"address-cri-api-v1~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):sum:sort(value(sum,descending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "Postcode lookup errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1102,
+        "left": 1140,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.di-ipv-cri-address-api.postcode_lookup_errorByAccountIdRegionpostcode_lookup_error_messagepostcode_lookup_error_type",
+          "spaceAggregation": "SUM",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "postcode_lookup_error_type"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "nestedFilters": [],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "STACKED_COLUMN",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            },
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "RIGHT",
+              "queryIds": [
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.di-ipv-cri-address-api.postcode_lookup_errorByAccountIdRegionpostcode_lookup_error_messagepostcode_lookup_error_type:splitBy(postcode_lookup_error_type):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Postcode lookup error msgs",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1102,
+        "left": 1520,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.di-ipv-cri-address-api.postcode_lookup_errorByAccountIdRegionpostcode_lookup_error_messagepostcode_lookup_error_type",
+          "spaceAggregation": "SUM",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "postcode_lookup_error_type",
+            "postcode_lookup_error_message"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "nestedFilters": [],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TOP_LIST",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.di-ipv-cri-address-api.postcode_lookup_errorByAccountIdRegionpostcode_lookup_error_messagepostcode_lookup_error_type:splitBy(postcode_lookup_error_type,postcode_lookup_error_message):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
Updated Orange Address Dashboards to include Postcode Errors Tiles

## Ticket number:
[OJ-2647]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[OJ-2647]: https://govukverify.atlassian.net/browse/OJ-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ