### PR TITLE
SPT-774 Update CIMIT API Gateway with requests per second

### DIFF
--- a/dashboards/spot/cimit-api-gateway.json
+++ b/dashboards/spot/cimit-api-gateway.json
@@ -29,7 +29,10 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["resource", "stage"],
+          "splitBy": [
+            "resource",
+            "stage"
+          ],
           "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(\"resource\",\"stage\"):sum:sort(value(auto,descending))",
           "rate": "NONE",
           "enabled": true
@@ -59,7 +62,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -121,7 +126,10 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["resource", "stage"],
+          "splitBy": [
+            "resource",
+            "stage"
+          ],
           "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(\"resource\",\"stage\"):sum:sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -202,7 +210,10 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["resource", "stage"],
+          "splitBy": [
+            "resource",
+            "stage"
+          ],
           "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(\"resource\",\"stage\"):sum:sort(value(auto,descending))",
           "rate": "NONE",
           "enabled": true
@@ -232,7 +243,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -294,7 +307,10 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["resource", "stage"],
+          "splitBy": [
+            "resource",
+            "stage"
+          ],
           "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(\"resource\",\"stage\"):sum:sort(value(auto,descending))",
           "rate": "NONE",
           "enabled": true
@@ -375,7 +391,10 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["resource", "stage"],
+          "splitBy": [
+            "resource",
+            "stage"
+          ],
           "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(\"resource\",\"stage\"):sum:sort(value(auto,descending))",
           "rate": "NONE",
           "enabled": true
@@ -405,7 +424,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -467,7 +488,10 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["resource", "stage"],
+          "splitBy": [
+            "resource",
+            "stage"
+          ],
           "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(\"resource\",\"stage\"):sum:sort(value(auto,descending))",
           "rate": "NONE",
           "enabled": true
@@ -528,6 +552,378 @@
       },
       "metricExpressions": [
         "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(eq(apiname,\"CIMIT Private API Gateway\"),eq(\"aws.region\",eu-west-2))):splitBy(resource,stage):sum:sort(value(auto,descending))):limit(100):names"
+      ]
+    },
+    {
+      "name": "API Gateway max requests/second (all resources)",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 912,
+        "left": 988,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy():count:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "1m",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=1m&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,\"CIMIT Private API Gateway\"),eq(\"aws.region\",eu-west-2))):splitBy():count:rate(1s):setUnit(PerSecond)):limit(100):names:fold(max)"
+      ]
+    },
+    {
+      "name": "API Gateway max requests/second (per resource)",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1216,
+        "left": 988,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(resource):count:rate(1s):setUnit(PerSecond):sort(value(avg,descending))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TOP_LIST",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "1m",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=1m&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,\"CIMIT Private API Gateway\"),eq(\"aws.region\",eu-west-2))):splitBy(resource):count:rate(1s):setUnit(PerSecond):sort(value(avg,descending))):limit(100):names:fold(max)"
+      ]
+    },
+    {
+      "name": "API Gateway requests/second (all resources)",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 912,
+        "left": 0,
+        "width": 988,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy():count:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": true
+        },
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "1m"
+      },
+      "metricExpressions": [
+        "resolution=1m&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,\"CIMIT Private API Gateway\"),eq(\"aws.region\",eu-west-2))):splitBy():count:rate(1s):setUnit(PerSecond)):limit(100):names"
+      ]
+    },
+    {
+      "name": "API Gateway requests/second (per resource)",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1216,
+        "left": 0,
+        "width": 988,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\",\"CIMIT Private API Gateway\"),eq(\"aws.region\",\"eu-west-2\"))):splitBy(resource):count:rate(1s):setUnit(PerSecond):sort(value(avg,descending))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "1m"
+      },
+      "metricExpressions": [
+        "resolution=1m&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,\"CIMIT Private API Gateway\"),eq(\"aws.region\",eu-west-2))):splitBy(resource):count:rate(1s):setUnit(PerSecond):sort(value(avg,descending))):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Add tiles to the existing CIMIT API Gateway dashboard that show the requests per second over time and maximum requests per second over a time period.

The data reported in these tiles are subject to the limitations of Dynatrace's resolution limits. I.e. over larger time periods Dynatrace uses a resolution that is greater, e.g. 5 minutes over 1 minute, and this leads to higher approximations for of the value of requests per second.

## Ticket number:
SPT-774

## Checklist:
- [x] Is my change backwards compatible? Adding data to a dashboard.
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
