### PR TITLE
PSREGOV-992/991: Added HMRC NINo, OTG, ReadID sessions and ReadID Tok…

### DIFF
--- a/settings_service_detection.tf
+++ b/settings_service_detection.tf
@@ -63,6 +63,38 @@ module "zendesk" {
   url    = "zendesk.com"
 }
 
+# ReadID Token Production Only
+module "readid_token" {
+  count  = local.is_production ? 1 : 0
+  source = "./modules/service_detection"
+  name   = "ReadID Token"
+  url    = "https://gds.readid.com/oauth/token"
+}
+
+# ReadID sessions Production Only
+module "readid_sessions" {
+  count  = local.is_production ? 1 : 0
+  source = "./modules/service_detection"
+  name   = "ReadID sessions"
+  url    = "https://gds.readid.com/odata/v1/ODataServlet/Sessions('<masked>')"
+}
+
+# HMRC NINo Production only
+module "hmrc_nino" {
+  count  = local.is_production ? 1 : 0
+  source = "./modules/service_detection"
+  name   = "HMRC NINo"
+  url    = "https://api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
+}
+
+# OTG Production only
+module "otg" {
+  count  = local.is_production ? 1 : 0
+  source = "./modules/service_detection"
+  name   = "OTG"
+  url    = "https://api.service.hmrc.gov.uk/oauth/token"
+}
+
 # DVA API Production only
 module "dva_api" {
   count  = local.is_production ? 1 : 0


### PR DESCRIPTION
…en to service detection file

# Description:
Added the 4 services listed within tickets 991 and 992 (HMRC NINo, OTG, ReadID sessions and ReadID Token) to settings_service_detection.tf and manually created the service naming rules for the corresponding services directly within the console.
## Ticket number:
[PSREGOV-991/992]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
