### PR TITLE
PSREGOV-992/991: Replaced ReadID Tokens, ReadID Sessions, HMRC NINo and…

### DIFF
--- a/settings_service_detection.tf
+++ b/settings_service_detection.tf
@@ -63,36 +63,112 @@ module "zendesk" {
   url    = "zendesk.com"
 }
 
-# ReadID Token Production Only
-module "readid_token" {
-  count  = local.is_production ? 1 : 0
-  source = "./modules/service_detection"
-  name   = "ReadID Token"
-  url    = "https://gds.readid.com/oauth/token"
+# ReadID Token Production only
+resource "dynatrace_service_external_web_service" "readid_token" {
+  name    = "ReadID Token"
+  enabled = true
+  conditions {
+    condition {
+      attribute              = "HostName"
+      compare_operation_type = "StringEndsWith"
+      text_values            = ["readid.com"]
+    },
+    condition {
+      attribute              = "Url"
+      compare_operation_type = "Contains"
+      text_values            = ["oauth/token"]
+    }
+  }
+  id_contributors {
+    public_domain_name {
+      enable_id_contributor = true
+      service_id_contributor {
+        contribution_type   = "OriginalValue"
+        copy_from_host_name = true
+      }
+    }
+  }
 }
 
-# ReadID sessions Production Only
-module "readid_sessions" {
-  count  = local.is_production ? 1 : 0
-  source = "./modules/service_detection"
-  name   = "ReadID sessions"
-  url    = "https://gds.readid.com/odata/v1/ODataServlet/Sessions('<masked>')"
+# ReadID Sessions Production only
+resource "dynatrace_service_external_web_service" "readid_sessions" {
+  name    = "ReadID sessions"
+  enabled = true
+  conditions {
+    condition {
+      attribute              = "HostName"
+      compare_operation_type = "StringEndsWith"
+      text_values            = ["readid.com"]
+    },
+    condition {
+      attribute              = "Url"
+      compare_operation_type = "Contains"
+      text_values            = ["odata/v1/ODataServlet"]
+    }
+  }
+  id_contributors {
+    public_domain_name {
+      enable_id_contributor = true
+      service_id_contributor {
+        contribution_type   = "OriginalValue"
+        copy_from_host_name = true
+      }
+    }
+  }
 }
 
 # HMRC NINo Production only
-module "hmrc_nino" {
-  count  = local.is_production ? 1 : 0
-  source = "./modules/service_detection"
-  name   = "HMRC NINo"
-  url    = "https://api.service.hmrc.gov.uk/individuals/authentication/authenticator/api/match"
+resource "dynatrace_service_external_web_service" "hmrc_nino" {
+  name    = "HMRC NINo"
+  enabled = true
+  conditions {
+    condition {
+      attribute              = "HostName"
+      compare_operation_type = "StringEndsWith"
+      text_values            = ["api.service.hmrc.gov.uk"]
+    },
+    condition {
+      attribute              = "Url"
+      compare_operation_type = "Contains"
+      text_values            = ["individuals/authentication"]
+    }
+  }
+  id_contributors {
+    public_domain_name {
+      enable_id_contributor = true
+      service_id_contributor {
+        contribution_type   = "OriginalValue"
+        copy_from_host_name = true
+      }
+    }
+  }
 }
 
 # OTG Production only
-module "otg" {
-  count  = local.is_production ? 1 : 0
-  source = "./modules/service_detection"
-  name   = "OTG"
-  url    = "https://api.service.hmrc.gov.uk/oauth/token"
+resource "dynatrace_service_external_web_service" "otg" {
+  name    = "OTG"
+  enabled = true
+  conditions {
+    condition {
+      attribute              = "HostName"
+      compare_operation_type = "StringEndsWith"
+      text_values            = ["api.service.hmrc.gov.uk"]
+    },
+    condition {
+      attribute              = "Url"
+      compare_operation_type = "Contains"
+      text_values            = ["oauth/token"]
+    }
+  }
+  id_contributors {
+    public_domain_name {
+      enable_id_contributor = true
+      service_id_contributor {
+        contribution_type   = "OriginalValue"
+        copy_from_host_name = true
+      }
+    }
+  }
 }
 
 # DVA API Production only


### PR DESCRIPTION
… OTG entries with different format

# Description:
Replaced existing ReadID Tokens, ReadID Sessions, HMRC NINo and OTG module entries with changed format within the settings_service_detection.tf  file to differentiate between what is being looked at per HostName.
## Ticket number:
[PSREGOV-992/991]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
