### PR TITLE
[QA-556]: Updated correct quota limits for KMS operations

### DIFF
--- a/dashboards/aws_service_quotas.json
+++ b/dashboards/aws_service_quotas.json
@@ -8,7 +8,7 @@
   },
   "tiles": [
     {
-      "name": "CryptographicOperationsSymmetric - Max 10,000/s",
+      "name": "CryptographicOperationsSymmetric - Max 20,000/s",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
@@ -25,10 +25,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsSymmetric\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
@@ -63,9 +60,7 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
+              "queryIds": ["A"],
               "defaultAxis": true
             }
           ]
@@ -81,11 +76,11 @@
                 "color": "#7dc540"
               },
               {
-                "value": 480000,
+                "value": 16000,
                 "color": "#f5d30f"
               },
               {
-                "value": 600000,
+                "value": 20000,
                 "color": "#dc172a"
               }
             ],
@@ -113,7 +108,7 @@
       ]
     },
     {
-      "name": "CryptographicOperationsRsa - Max 500/s",
+      "name": "CryptographicOperationsRsa - Max 1000/s",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
@@ -130,10 +125,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsRsa\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
@@ -168,9 +160,7 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
+              "queryIds": ["A"],
               "defaultAxis": true
             }
           ]
@@ -186,11 +176,11 @@
                 "color": "#7dc540"
               },
               {
-                "value": 400,
+                "value": 800,
                 "color": "#f5d30f"
               },
               {
-                "value": 500,
+                "value": 1000,
                 "color": "#dc172a"
               }
             ],
@@ -218,7 +208,7 @@
       ]
     },
     {
-      "name": "CryptographicOperationsEcc - Max 300/s",
+      "name": "CryptographicOperationsEcc - Max 1000/s",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
@@ -235,10 +225,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsEcc\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
@@ -273,9 +260,7 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
+              "queryIds": ["A"],
               "defaultAxis": true
             }
           ]
@@ -291,11 +276,11 @@
                 "color": "#7dc540"
               },
               {
-                "value": 240,
+                "value": 800,
                 "color": "#f5d30f"
               },
               {
-                "value": 300,
+                "value": 1000,
                 "color": "#dc172a"
               }
             ],
@@ -340,9 +325,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device"
-          ],
+          "splitBy": ["dt.entity.custom_device"],
           "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeSecret\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
@@ -377,9 +360,7 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
+              "queryIds": ["A"],
               "defaultAxis": true
             }
           ]
@@ -444,10 +425,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"ListSecrets\")):splitBy(\"aws.account.id\"):sum:rate(1s):setUnit(PerSecond)",
           "rate": "NONE",
           "enabled": true
@@ -482,9 +460,7 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
+              "queryIds": ["A"],
               "defaultAxis": true
             }
           ]
@@ -591,10 +567,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsEcc\")):splitBy(\"aws.account.id\"):sum:rate(1s)/300)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
@@ -690,10 +663,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsRsa\")):splitBy(\"aws.account.id\"):sum:rate(1s)/500)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
@@ -789,10 +759,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"CryptographicOperationsSymmetric\")):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
@@ -888,10 +855,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(or(eq(\"resource\",\"DescribeSecret\"),eq(\"resource\",\"GetSecretValue\"))):splitBy(\"aws.account.id\"):sum:rate(1s)/10000)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true
@@ -987,10 +951,7 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "dt.entity.custom_device",
-            "Resource"
-          ],
+          "splitBy": ["dt.entity.custom_device", "Resource"],
           "metricSelector": "((cloud.aws.usage.callCountByAccountIdClassRegionResourceServiceType:filter(eq(\"resource\",\"ListSecrets\")):splitBy(\"aws.account.id\"):sum:rate(1s)/100)*100):setUnit(Percent)",
           "rate": "NONE",
           "enabled": true


### PR DESCRIPTION
# Description:
AWS has increased the default quota limits for KMS cryptographic operations to
- Symmetric - 20,000 requests per second.
- ECC and RSA - 1,000 requests per second
This ticket/PR is to update the AWS Service Quota dynatrace dashboard to reflect the increase quota limits

## Ticket number:
[QA-556]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
