### PR TITLE
PSREDEV-1276: remove hosted-zones from devplatform dora dashboard

### DIFF
--- a/dashboards/dev-platform/pipelines-list-multi-sam-stack-names.csv
+++ b/dashboards/dev-platform/pipelines-list-multi-sam-stack-names.csv
@@ -97,7 +97,6 @@ devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,codemetrics-ui,co
 devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,demo-sam-app,demo-sam-app,demo-sam-app,demo-sam-app,demo-sam-app
 devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,demo-sam-app2,demo-sam-app2,demo-sam-app2,demo-sam-app2,demo-sam-app2
 devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,fraud-stackset,fraud-stackset,fraud-stackset,fraud-stackset,fraud-stackset
-devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,hosted-zone,hosted-zone,hosted-zone,hosted-zone,hosted-zone
 devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,node-app,node-app,node-app,node-app,node-app
 devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,pact-broker-stack,pact-broker-stack,pact-broker-stack,pact-broker-stack,pact-broker-stack
 devplatform,di-dev-platform-core@digital.cabinet-office.gov.uk,pact-flow-stack,pact-flow-stack,pact-flow-stack,pact-flow-stack,pact-flow-stack


### PR DESCRIPTION
# Description:
- Removed hosted-zones pipeline from devplatform's dora dashboard
## Ticket number:
[PSREDEV-1276]

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
