### PR TITLE
[QA-559]: Include Unhealthy Host Count in Perf BE & FE dashboard

### DIFF
--- a/dashboards/capacity/application-performance-review.json
+++ b/dashboards/capacity/application-performance-review.json
@@ -1607,6 +1607,17 @@
           "metricSelector": "cloud.aws.ecs.containerinsights.desiredTaskCountByAccountIdClusterNameRegionServiceName:splitBy(servicename)",
           "rate": "NONE",
           "enabled": true
+        },
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "targetgroup"
+          ],
+          "metricSelector": "cloud.aws.applicationelb.unHealthyHostCountByAccountIdLoadBalancerRegionTargetGroup:splitBy(targetgroup)",
+          "rate": "NONE",
+          "enabled": true
         }
       ],
       "visualConfig": {
@@ -1633,6 +1644,13 @@
               "color": "DEFAULT"
             },
             "seriesOverrides": []
+          },
+          {
+            "matcher": "F:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
           }
         ],
         "axes": {
@@ -1650,7 +1668,8 @@
               "queryIds": [
                 "C",
                 "D",
-                "E"
+                "E",
+                "F"
               ],
               "defaultAxis": true
             }


### PR DESCRIPTION
# Description:

In the `Performance BE & FE` dynatrace dashboard, the `Task Count by Service` panel shows the status of ECS tasks. This should also include Unhealthy Host Count to monitor if there are any unhealthy FE containers.

Metric Used - `cloud.aws.applicationelb.unHealthyHostCountByAccountIdLoadBalancerRegionTargetGroup`

## Ticket number:
[QA-559]


[QA-559]: https://govukverify.atlassian.net/browse/QA-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ