### PR TITLE
error_codes is meant to be a String

### DIFF
--- a/modules/web_application/error_rules.tf
+++ b/modules/web_application/error_rules.tf
@@ -9,7 +9,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_blocked_requests   = false
       consider_for_ai             = false
       consider_unknown_error_code = false
-      error_codes                 = 404
+      error_codes                 = "404"
       impact_apdex                = false
       filter_by_url               = true
       filter                      = "ENDS_WITH"
@@ -20,7 +20,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_blocked_requests   = false
       consider_for_ai             = true
       consider_unknown_error_code = false
-      error_codes                 = 404
+      error_codes                 = "404"
       impact_apdex                = false
       filter_by_url               = true
       filter                      = "ENDS_WITH"
@@ -31,7 +31,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_blocked_requests   = false
       consider_for_ai             = true
       consider_unknown_error_code = false
-      error_codes                 = 404
+      error_codes                 = "404"
       impact_apdex                = false
       filter_by_url               = true
       filter                      = "ENDS_WITH"
@@ -42,7 +42,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_blocked_requests   = false
       consider_for_ai             = false
       consider_unknown_error_code = false
-      error_codes                 = 400-499
+      error_codes                 = "400-499"
       impact_apdex                = false
       filter_by_url               = false
     }
@@ -51,7 +51,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_blocked_requests   = false
       consider_for_ai             = true
       consider_unknown_error_code = false
-      error_codes                 = 500-599
+      error_codes                 = "500-599"
       impact_apdex                = true
       filter_by_url               = false
     }
@@ -60,7 +60,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_blocked_requests   = false
       consider_for_ai             = false
       consider_unknown_error_code = false
-      error_codes                 = 970-979
+      error_codes                 = "970-979"
       impact_apdex                = true
       filter_by_url               = false
     }


### PR DESCRIPTION
# Description:
Missed that the "error_codes" attribute is meant to be a String.

## Ticket number:
PSREGOV-1082

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
