### PR TITLE
ATB-1807: handle new VC_SAVED metric with provenance dimension added

### DIFF
--- a/dashboards/encrypted-vc-storage/encrypted_vc_storage_dashboard.json
+++ b/dashboards/encrypted-vc-storage/encrypted_vc_storage_dashboard.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.297.34.20240731-021454"
+    "clusterVersion": "1.299.38.20240829-085520"
   },
   "dashboardMetadata": {
     "name": "Encrypted VC Storage (EVCS)",
@@ -1442,97 +1442,14 @@
       ]
     },
     {
-      "name": "VCs Saved",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 38,
-        "left": 1520,
-        "width": 380,
-        "height": 266
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Pie",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "state"
-          ],
-          "metricSelector": "cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionservicestate:splitBy(state):sum:sort(value(sum,descending))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "PIE_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionservicestate:splitBy(state):sum:sort(value(sum,descending))):limit(100):names"
-      ]
-    },
-    {
       "name": "Invalid Audit Events & TxMA Publish Issues",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 684,
+        "top": 950,
         "left": 2280,
         "width": 380,
-        "height": 380
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -1684,8 +1601,8 @@
       "configured": true,
       "bounds": {
         "top": 38,
-        "left": 1900,
-        "width": 190,
+        "left": 1976,
+        "width": 228,
         "height": 266
       },
       "tileFilter": {},
@@ -1783,8 +1700,8 @@
       "configured": true,
       "bounds": {
         "top": 38,
-        "left": 2090,
-        "width": 190,
+        "left": 2204,
+        "width": 228,
         "height": 266
       },
       "tileFilter": {},
@@ -2211,10 +2128,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 684,
+        "top": 950,
         "left": 1520,
         "width": 380,
-        "height": 380
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -2421,10 +2338,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 684,
+        "top": 950,
         "left": 1900,
         "width": 380,
-        "height": 380
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -2624,10 +2541,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1064,
+        "top": 1216,
         "left": 2280,
         "width": 380,
-        "height": 380
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -2947,10 +2864,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1064,
+        "top": 1216,
         "left": 1520,
         "width": 380,
-        "height": 380
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -3270,10 +3187,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1064,
+        "top": 1216,
         "left": 1900,
         "width": 380,
-        "height": 380
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -4330,8 +4247,8 @@
       "configured": true,
       "bounds": {
         "top": 38,
-        "left": 2280,
-        "width": 190,
+        "left": 2432,
+        "width": 228,
         "height": 266
       },
       "tileFilter": {},
@@ -4449,10 +4366,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1444,
+        "top": 1482,
         "left": 1520,
         "width": 1140,
-        "height": 266
+        "height": 228
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -4559,10 +4476,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 342,
+        "top": 684,
         "left": 1520,
         "width": 380,
-        "height": 342
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -4861,10 +4778,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 342,
+        "top": 684,
         "left": 1900,
         "width": 380,
-        "height": 342
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -5017,10 +4934,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 342,
+        "top": 684,
         "left": 2280,
         "width": 380,
-        "height": 342
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -5314,7 +5231,7 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 304,
+        "top": 646,
         "left": 1520,
         "width": 190,
         "height": 38
@@ -6474,6 +6391,284 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(contains(queuename,id-reuse-storage-main)):splitBy(queuename):fold(sum)):names:fold(auto),(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(contains(queuename,id-reuse-storage-main)):splitBy(queuename):fold(sum)):names:fold(auto),(cloud.aws.sqs.numberOfMessagesDeletedByAccountIdQueueNameRegion:filter(contains(queuename,id-reuse-storage-main)):splitBy(queuename):fold(sum)):names:fold(auto),(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(contains(queuename,id-reuse-storage-main)):splitBy(queuename):fold(sum)):names:fold(auto),(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(contains(queuename,id-reuse-storage-main)):splitBy(queuename):fold(max)):names:fold(auto),(cloud.aws.sqs.sentMessageSizeByAccountIdQueueNameRegion:filter(contains(queuename,id-reuse-storage-main)):splitBy(queuename):fold(avg)):names:fold(auto),(cloud.aws.sqs.sentMessageSizeByAccountIdQueueNameRegion:filter(contains(queuename,id-reuse-storage-main)):splitBy(queuename):fold(max)):names:fold(auto)"
+      ]
+    },
+    {
+      "name": "VCs Saved",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 1520,
+        "width": 456,
+        "height": 266
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Pie",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "state"
+          ],
+          "metricSelector": "(cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionservicestate:splitBy(\"state\"):sum:default(0) + cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:splitBy(\"state\"):sum:default(0)):sort(value(sum,descending)) ",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "PIE_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:state.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "SUM"
+      },
+      "metricExpressions": [
+        "resolution=null&((cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionservicestate:splitBy(state):sum:default(0)+cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:splitBy(state):sum:default(0)):sort(value(sum,descending))):limit(100):names:fold(sum)"
+      ]
+    },
+    {
+      "name": "VCs Saved by Provenance per State (New)",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 1520,
+        "width": 1140,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Pie",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "state"
+          ],
+          "metricSelector": "cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(\"provenance\",\"1\")):splitBy(state):sum:default(0):sort(dimension(\"state\",ascending))",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "state"
+          ],
+          "metricSelector": "cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(\"provenance\",\"2\")):splitBy(state):sum:default(0):sort(dimension(\"state\",ascending))",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "state"
+          ],
+          "metricSelector": "cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(\"provenance\",\"4\")):splitBy(state):sum:default(0):sort(dimension(\"state\",ascending))",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "state"
+          ],
+          "metricSelector": "cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(\"provenance\",\"3\")):splitBy(state):sum:default(0):sort(dimension(\"state\",ascending))",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "state"
+          ],
+          "metricSelector": "cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(\"provenance\",\"5\")):splitBy(state):sum:default(0):sort(dimension(\"state\",ascending))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA",
+              "alias": "Online (1)"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Offline (2)"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA",
+              "alias": "Migrated (4)"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA",
+              "alias": "External (3)"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA",
+              "alias": "Other (5)"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "",
+            "rules": [
+              {
+                "value": 2,
+                "color": "#7dc540"
+              },
+              {
+                "value": 1,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 0,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "E",
+            "visible": false
+          }
+        ],
+        "tableSettings": {
+          "isThresholdBackgroundAppliedToCell": true,
+          "hiddenColumns": [
+            "A:state.name",
+            "B:state.name",
+            "D:state.name",
+            "C:state.name",
+            "E:state.name",
+            "F:state.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "SUM"
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(provenance,\"1\")):splitBy(state):sum:default(0):sort(dimension(state,ascending))):names:fold(sum),(cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(provenance,\"2\")):splitBy(state):sum:default(0):sort(dimension(state,ascending))):names:fold(sum),(cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(provenance,\"4\")):splitBy(state):sum:default(0):sort(dimension(state,ascending))):names:fold(sum),(cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(provenance,\"3\")):splitBy(state):sum:default(0):sort(dimension(state,ascending))):names:fold(sum),(cloud.aws.vcstorage.vC_SAVEDByAccountIdRegionprovenanceservicestate:filter(eq(provenance,\"5\")):splitBy(state):sum:default(0):sort(dimension(state,ascending))):names:fold(sum)"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
Updated EVCS dashboard to handle new VC_SAVED metric with provenance dimension added.


<img width="1571" alt="Screenshot 2024-09-10 at 17 35 51" src="https://github.com/user-attachments/assets/f9d837a0-8962-48ee-b79c-9354308dbaf0">

## Ticket number:
[ATB-1807]

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:


[ATB-1807]: https://govukverify.atlassian.net/browse/ATB-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ