### PR TITLE
PSREGOV-1191: Remove 97x and CSP Violations from Apdex calculation for RUM apps

### DIFF
--- a/modules/web_application/error_rules.tf
+++ b/modules/web_application/error_rules.tf
@@ -61,7 +61,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_for_ai             = false
       consider_unknown_error_code = false
       error_codes                 = "970-979"
-      impact_apdex                = true
+      impact_apdex                = false
       filter_by_url               = false
     }
     rule {
@@ -77,7 +77,7 @@ resource "dynatrace_application_error_rules" "web_application" {
       consider_blocked_requests   = true
       consider_for_ai             = true
       consider_unknown_error_code = false
-      impact_apdex                = true
+      impact_apdex                = false
       filter_by_url               = false
     }
   }

--- a/modules/web_application/main.tf
+++ b/modules/web_application/main.tf
@@ -6,16 +6,16 @@ resource "dynatrace_web_application" "web_application" {
   real_user_monitoring_enabled         = var.enabled
   xhr_action_key_performance_metric    = "VISUALLY_COMPLETE"
   custom_action_apdex_settings {
-    frustrating_fallback_threshold = 12000
-    frustrating_threshold          = 12000
-    tolerated_fallback_threshold   = 3000
-    tolerated_threshold            = 3000
+    frustrating_fallback_threshold = 15000
+    frustrating_threshold          = 15000
+    tolerated_fallback_threshold   = 8000
+    tolerated_threshold            = 8000
   }
   load_action_apdex_settings {
-    frustrating_fallback_threshold = 12000
-    frustrating_threshold          = 12000
-    tolerated_fallback_threshold   = 3000
-    tolerated_threshold            = 3000
+    frustrating_fallback_threshold = 15000
+    frustrating_threshold          = 15000
+    tolerated_fallback_threshold   = 8000
+    tolerated_threshold            = 8000
   }
   monitoring_settings {
     cache_control_header_optimizations = true


### PR DESCRIPTION
# Description:
The Apdex scores for each RUM application is taking into account 97x Error Codes and CSP Violations are removed from Apdex ratings, but these are google analytics tagmanager errors and CSP inconsistencies between frontends, respectively, and should not be included in Apdex ratings. Use this ticket to remove the above mentioned error codes from consideration and identify what else is being included in Apdex ratings that can be removed.

# User Story
As a Engineer
I want to filter out incorrect data from Apdex ratings So that the ratings being generated don’t contain user-generated errors And instead reflect the true definition of Apdex ratings for a web application

# Acceptance criteria
- 97x Error Codes are removed from Apdex ratings
- CSP Violations are removed from Apdex ratings
- Change Visually Complete Apdex timings to 8s/15s from 3s/12s

## Ticket number:
[PSREGOV-1191]

## Checklist:
- [ X ] Is my change backwards compatible? Please include evidence
  - Changes were carefully tested as working on prod instance (due to lack of sufficient traffic in non-prod)
- [ X ] I have tested this and added output to Jira Comment: https://govukverify.atlassian.net/browse/PSREGOV-1191?focusedCommentId=172245
- [ X ] Documentation added (link) Comment: https://govukverify.atlassian.net/browse/PSREGOV-1191


[PSREGOV-1191]: https://govukverify.atlassian.net/browse/PSREGOV-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ