### PR TITLE
PSREGOV-1229: replace inline GHA IAM role ARNs with repo secret

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Check dashboard IDs not present
         run: |
           for file in dashboards/*.json dashboards/**/*.json; do
@@ -36,7 +36,7 @@ jobs:
               exit 1
             fi
           done
-          
+
       - name: Check dashboard tiles are sorted by name
         run: |
           for file in dashboards/signin-signup.json; do
@@ -62,8 +62,8 @@ jobs:
 
   Check_NonProd:
     env:
-      DYNATRACE_API_TOKEN: ${{ secrets.NONPROD_DYNATRACE_API_TOKEN}}
-      DYNATRACE_ENV_URL: ${{ secrets.NONPROD_DYNATRACE_ENV_URL}}
+      DYNATRACE_API_TOKEN: ${{ secrets.NONPROD_DYNATRACE_API_TOKEN }}
+      DYNATRACE_ENV_URL: ${{ secrets.NONPROD_DYNATRACE_ENV_URL }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -76,12 +76,12 @@ jobs:
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::892537467220:role/ObservationConfigurationGitHubIde-GitHubActionsRole-MdPyTyImAExz
+          role-to-assume: ${{ secrets.GHA_OBSERVABILITY_CONFIG_IAM_ROLE_ARN }}
           aws-region: eu-west-2
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
       - run: pip install -r requirements.txt
 
       - run: ./get-accounts.py 'non-production'
@@ -126,12 +126,12 @@ jobs:
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::892537467220:role/ObservationConfigurationGitHubIde-GitHubActionsRole-MdPyTyImAExz
+          role-to-assume: ${{ secrets.GHA_OBSERVABILITY_CONFIG_IAM_ROLE_ARN }}
           aws-region: eu-west-2
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
       - run: pip install -r requirements.txt
 
       - run: ./get-accounts.py 'production'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,8 @@ env:
 jobs:
   DeployNonProd:
     env:
-      DYNATRACE_API_TOKEN: ${{ secrets.NONPROD_DYNATRACE_API_TOKEN}}
-      DYNATRACE_ENV_URL: ${{ secrets.NONPROD_DYNATRACE_ENV_URL}}
+      DYNATRACE_API_TOKEN: ${{ secrets.NONPROD_DYNATRACE_API_TOKEN }}
+      DYNATRACE_ENV_URL: ${{ secrets.NONPROD_DYNATRACE_ENV_URL }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -33,12 +33,12 @@ jobs:
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::892537467220:role/ObservationConfigurationGitHubIde-GitHubActionsRole-MdPyTyImAExz
+          role-to-assume: ${{ secrets.GHA_OBSERVABILITY_CONFIG_IAM_ROLE_ARN }}
           aws-region: eu-west-2
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
       - run: pip install -r requirements.txt
 
       - run: ./get-accounts.py 'non-production'
@@ -68,8 +68,8 @@ jobs:
         run: terraform apply -var environment=nonproduction -auto-approve -refresh=false
   DeployProd:
     env:
-      DYNATRACE_API_TOKEN: ${{ secrets.PROD_DYNATRACE_API_TOKEN}}
-      DYNATRACE_ENV_URL: ${{ secrets.PROD_DYNATRACE_ENV_URL}}
+      DYNATRACE_API_TOKEN: ${{ secrets.PROD_DYNATRACE_API_TOKEN }}
+      DYNATRACE_ENV_URL: ${{ secrets.PROD_DYNATRACE_ENV_URL }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -82,12 +82,12 @@ jobs:
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::892537467220:role/ObservationConfigurationGitHubIde-GitHubActionsRole-MdPyTyImAExz
+          role-to-assume: ${{ secrets.GHA_OBSERVABILITY_CONFIG_IAM_ROLE_ARN }}
           aws-region: eu-west-2
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
       - run: pip install -r requirements.txt
 
       - run: ./get-accounts.py 'production'


### PR DESCRIPTION
# Description:

Replaces the hardcoded IAM role ARN with a value provided by a repo secret.

This PR should not be merged until the secret has been added to the repo under Security -> Secrets and variables -> Actions -> + New repo secret.

The Action status checks will fail until the PR is merged because Github will not allow a PR to read repo secrets

## Ticket number:
[PSREGOV-1229]

## Checklist:
- [x] Is my change backwards compatible? Please include evidence


[PSREGOV-1229]: https://govukverify.atlassian.net/browse/PSREGOV-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ