### PR TITLE
Updating unique IDs because of previous usage

### DIFF
--- a/modules/web_application/main.tf
+++ b/modules/web_application/main.tf
@@ -136,7 +136,7 @@ resource "dynatrace_web_application" "web_application" {
     property {
       aggregation                   = "FIRST"
       display_name                  = "Referrer"
-      id                            = 1
+      id                            = 10
       ignore_case                   = false
       key                           = "web_referrer"
       long_string_length            = 0
@@ -149,7 +149,7 @@ resource "dynatrace_web_application" "web_application" {
     property {
       aggregation                   = "LAST"
       display_name                  = "User agent"
-      id                            = 2
+      id                            = 11
       ignore_case                   = false
       key                           = "web_useragent"
       long_string_length            = 0
@@ -162,7 +162,7 @@ resource "dynatrace_web_application" "web_application" {
     property {
       aggregation                   = "LAST"
       display_name                  = "UTM source"
-      id                            = 3
+      id                            = 12
       ignore_case                   = false
       key                           = "web_utm_source"
       long_string_length            = 0
@@ -175,7 +175,7 @@ resource "dynatrace_web_application" "web_application" {
     property {
       aggregation                   = "LAST"
       display_name                  = "UTM medium"
-      id                            = 4
+      id                            = 13
       ignore_case                   = false
       key                           = "web_utm_medium"
       long_string_length            = 0
@@ -188,7 +188,7 @@ resource "dynatrace_web_application" "web_application" {
     property {
       aggregation                   = "LAST"
       display_name                  = "UTM campaign"
-      id                            = 5
+      id                            = 14
       ignore_case                   = false
       key                           = "web_utm_campaign"
       long_string_length            = 0
@@ -201,7 +201,7 @@ resource "dynatrace_web_application" "web_application" {
     property {
       aggregation                   = "LAST"
       display_name                  = "UTM term"
-      id                            = 6
+      id                            = 15
       ignore_case                   = false
       key                           = "web_utm_term"
       long_string_length            = 0
@@ -214,7 +214,7 @@ resource "dynatrace_web_application" "web_application" {
     property {
       aggregation                   = "LAST"
       display_name                  = "UTM content"
-      id                            = 7
+      id                            = 16
       ignore_case                   = false
       key                           = "web_utm_content"
       long_string_length            = 0

--- a/modules/web_application/main.tf
+++ b/modules/web_application/main.tf
@@ -80,7 +80,7 @@ resource "dynatrace_web_application" "web_application" {
       name            = "Referrer"
       public_metadata = false
       type            = "JAVA_SCRIPT_VARIABLE"
-      unique_id       = 1
+      unique_id       = 10
       use_last_value  = false
     }
     capture {
@@ -88,7 +88,7 @@ resource "dynatrace_web_application" "web_application" {
       name            = "User agent"
       public_metadata = false
       type            = "JAVA_SCRIPT_VARIABLE"
-      unique_id       = 2
+      unique_id       = 11
       use_last_value  = false
     }
     capture {
@@ -96,7 +96,7 @@ resource "dynatrace_web_application" "web_application" {
       name            = "UTM source"
       public_metadata = false
       type            = "QUERY_STRING"
-      unique_id       = 3
+      unique_id       = 12
       use_last_value  = false
     }
     capture {
@@ -104,7 +104,7 @@ resource "dynatrace_web_application" "web_application" {
       name            = "UTM medium"
       public_metadata = false
       type            = "QUERY_STRING"
-      unique_id       = 4
+      unique_id       = 13
       use_last_value  = false
     }
     capture {
@@ -112,7 +112,7 @@ resource "dynatrace_web_application" "web_application" {
       name            = "UTM campaign"
       public_metadata = false
       type            = "QUERY_STRING"
-      unique_id       = 5
+      unique_id       = 14
       use_last_value  = false
     }
     capture {
@@ -120,7 +120,7 @@ resource "dynatrace_web_application" "web_application" {
       name            = "UTM term"
       public_metadata = false
       type            = "QUERY_STRING"
-      unique_id       = 6
+      unique_id       = 15
       use_last_value  = false
     }
     capture {
@@ -128,7 +128,7 @@ resource "dynatrace_web_application" "web_application" {
       name            = "UTM content"
       public_metadata = false
       type            = "QUERY_STRING"
-      unique_id       = 7
+      unique_id       = 16
       use_last_value  = false
     }
   }
@@ -140,7 +140,7 @@ resource "dynatrace_web_application" "web_application" {
       ignore_case                   = false
       key                           = "web_referrer"
       long_string_length            = 0
-      metadata_id                   = 1
+      metadata_id                   = 10
       origin                        = "META_DATA"
       store_as_session_property     = true
       store_as_user_action_property = false
@@ -153,7 +153,7 @@ resource "dynatrace_web_application" "web_application" {
       ignore_case                   = false
       key                           = "web_useragent"
       long_string_length            = 0
-      metadata_id                   = 2
+      metadata_id                   = 11
       origin                        = "META_DATA"
       store_as_session_property     = true
       store_as_user_action_property = false
@@ -166,7 +166,7 @@ resource "dynatrace_web_application" "web_application" {
       ignore_case                   = false
       key                           = "web_utm_source"
       long_string_length            = 0
-      metadata_id                   = 3
+      metadata_id                   = 12
       origin                        = "META_DATA"
       store_as_session_property     = true
       store_as_user_action_property = false
@@ -179,7 +179,7 @@ resource "dynatrace_web_application" "web_application" {
       ignore_case                   = false
       key                           = "web_utm_medium"
       long_string_length            = 0
-      metadata_id                   = 4
+      metadata_id                   = 13
       origin                        = "META_DATA"
       store_as_session_property     = true
       store_as_user_action_property = false
@@ -192,7 +192,7 @@ resource "dynatrace_web_application" "web_application" {
       ignore_case                   = false
       key                           = "web_utm_campaign"
       long_string_length            = 0
-      metadata_id                   = 5
+      metadata_id                   = 14
       origin                        = "META_DATA"
       store_as_session_property     = true
       store_as_user_action_property = false
@@ -205,7 +205,7 @@ resource "dynatrace_web_application" "web_application" {
       ignore_case                   = false
       key                           = "web_utm_term"
       long_string_length            = 0
-      metadata_id                   = 6
+      metadata_id                   = 15
       origin                        = "META_DATA"
       store_as_session_property     = true
       store_as_user_action_property = false
@@ -218,7 +218,7 @@ resource "dynatrace_web_application" "web_application" {
       ignore_case                   = false
       key                           = "web_utm_content"
       long_string_length            = 0
-      metadata_id                   = 7
+      metadata_id                   = 16
       origin                        = "META_DATA"
       store_as_session_property     = true
       store_as_user_action_property = false


### PR DESCRIPTION
# Description:
IDs need to be unique and Dynatrace had already created a few before deleting them and so in theory, the sequence should have started from 2.
To avoid having to add conditionals to both Auth and IPV Core, I'm starting the sequence fresh from 10. 

## Ticket number:
PSREGOV-1236

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
