### PR TITLE
Added in new global suppression rule for invalid session

### DIFF
--- a/settings_server_side_service_monitoring.tf
+++ b/settings_server_side_service_monitoring.tf
@@ -738,6 +738,32 @@ resource "dynatrace_failure_detection_parameters" "ignore_missing_prereq_for_thi
   }
 }
 
+resource "dynatrace_failure_detection_parameters" "invalid_session" {
+  name = "invalid-session"
+
+  broken_links {
+    http_404_not_found_failures = false
+  }
+
+  http_response_codes {
+    client_side_errors                        = "400-599"
+    server_side_errors                        = "500-599"
+    fail_on_missing_response_code_client_side = false
+    fail_on_missing_response_code_server_side = false
+  }
+
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = false
+
+    ignored_exceptions {
+      custom_handled_exception {
+        message_pattern = "Invalid session and referrer does not have gov.uk domain"
+      }
+    }
+  }
+}
+
 # Failure detection rules
 resource "dynatrace_failure_detection_rules" "ignore_page_not_found" {
   name         = "ignore-page-not-found"
@@ -781,6 +807,25 @@ resource "dynatrace_failure_detection_rules" "ignore_missing_prereq_for_this_ste
   name         = "ignore-missing-prereq-for-this-step"
   enabled      = true
   parameter_id = dynatrace_failure_detection_parameters.ignore_missing_prereq_for_this_step.id
+
+  conditions {
+    condition {
+      attribute = "SERVICE_TYPE"
+      predicate {
+        predicate_type = "SERVICE_TYPE_EQUALS"
+        service_type = [
+          "WebRequest",
+          "WebService"
+        ]
+      }
+    }
+  }
+}
+
+resource "dynatrace_failure_detection_rules" "invalid_session" {
+  name         = "invalid-session"
+  enabled      = true
+  parameter_id = dynatrace_failure_detection_parameters.invalid_session.id
 
   conditions {
     condition {


### PR DESCRIPTION
# Description:
Creation of a new global suppression rule for the invalid session error being received by TSD, approval from both teams and TSD that this can be suppressed has been given.

## Ticket number:
PSREGOV-1290

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
