### PR TITLE
PSREDEV-387: add extra filter to int & prod envs

### DIFF
--- a/dashboards/dev-platform/teams_pipeline_dora_dashboard_cfr.tftpl
+++ b/dashboards/dev-platform/teams_pipeline_dora_dashboard_cfr.tftpl
@@ -145,7 +145,7 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [],
-          "metricSelector": "(((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${sam_stack_name_production[i]}\"),eq(stage,deploy),eq(environment,production))):splitBy():count)\n-\n(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${sam_stack_name_production[i]}\"),eq(environment,production))):splitBy():count))\n/\n(devplatform.sam-pipelines.deployment:filter(and(eq(\"sam-stack-name\",\"${sam_stack_name_production[i]}\"),eq(stage,deploy),eq(environment,production))):splitBy():count))*100",
+          "metricSelector": "(((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${sam_stack_name_production[i]}\"),eq(stage,deploy),eq(environment,production))):splitBy():count)\n-\n(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${sam_stack_name_production[i]}\"),eq(stage,deploy),eq(environment,production))):splitBy():count))\n/\n(devplatform.sam-pipelines.deployment:filter(and(eq(\"sam-stack-name\",\"${sam_stack_name_production[i]}\"),eq(stage,deploy),eq(environment,production))):splitBy():count))*100",
           "rate": "NONE",
           "enabled": true
         }
@@ -157,7 +157,7 @@
           {
             "matcher": "A:",
             "unitTransform": "%",
-            "valueFormat": "auto",
+            "valueFormat": "0,00",
             "properties": {
               "color": "DEFAULT",
               "seriesType": "LINE"
@@ -212,8 +212,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count))*100):limit(100):names",
-        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count))*100)"
+        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count))*100):limit(100):names",
+        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,production))):splitBy():count))*100)"
       ]
     },
     {
@@ -247,7 +247,7 @@
           {
             "matcher": "A:",
             "unitTransform": "%",
-            "valueFormat": "auto",
+            "valueFormat": "0,00",
             "properties": {
               "color": "DEFAULT",
               "seriesType": "LINE"
@@ -325,7 +325,7 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [],
-          "metricSelector": "(((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${sam_stack_name_integration[i]}\"),eq(stage,deploy),eq(environment,integration))):splitBy():count)\n-\n(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${sam_stack_name_integration[i]}\"),eq(environment,integration))):splitBy():count))\n/\n(devplatform.sam-pipelines.deployment:filter(and(eq(\"sam-stack-name\",\"${sam_stack_name_integration[i]}\"),eq(stage,deploy),eq(environment,integration))):splitBy():count))*100",
+          "metricSelector": "(((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,\"${sam_stack_name_integration[i]}\"),eq(stage,deploy),eq(environment,integration))):splitBy():count)\n-\n(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,\"${sam_stack_name_integration[i]}\"),eq(stage,deploy),eq(environment,integration))):splitBy():count))\n/\n(devplatform.sam-pipelines.deployment:filter(and(eq(\"sam-stack-name\",\"${sam_stack_name_integration[i]}\"),eq(stage,deploy),eq(environment,integration))):splitBy():count))*100",
           "rate": "NONE",
           "enabled": true
         }
@@ -337,7 +337,7 @@
           {
             "matcher": "A:",
             "unitTransform": "%",
-            "valueFormat": "auto",
+            "valueFormat": "0,00",
             "properties": {
               "color": "DEFAULT",
               "seriesType": "LINE"
@@ -392,8 +392,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(environment,integration))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count))*100):limit(100):names",
-        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(environment,integration))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count))*100)"
+        "resolution=Inf&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count))*100):limit(100):names",
+        "resolution=null&((((devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count)-(devplatform.sam-pipelines.deployment:filter(and(eq(build-success,\"1\"),eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count))/(devplatform.sam-pipelines.deployment:filter(and(eq(sam-stack-name,backend-api),eq(stage,deploy),eq(environment,integration))):splitBy():count))*100)"
       ]
     },
     {
@@ -427,7 +427,7 @@
           {
             "matcher": "A:",
             "unitTransform": "%",
-            "valueFormat": "auto",
+            "valueFormat": "0,00",
             "properties": {
               "color": "DEFAULT",
               "seriesType": "LINE"


### PR DESCRIPTION
# Description:
- Some dashboards were showing negative Change Failure Rate values for integration environment
- This is due to dashboards not accounting for a test phase in integration
- This is fixed by adding an extra filter to integration and production environments to only account for deploy stage 
metrics
- Added missing formatting 0.00% for CFR across environments tiles
## Ticket number:
[PSREDEV-387]

[PSREDEV-387]: https://govukverify.atlassian.net/browse/PSREDEV-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ