### PR TITLE
Error in the comparison type

### DIFF
--- a/settings_server_side_service_monitoring.tf
+++ b/settings_server_side_service_monitoring.tf
@@ -44,8 +44,8 @@ resource "dynatrace_calculated_service_metric" "ipv-core-response-time" {
       attribute = "SERVICE_DISPLAY_NAME"
       comparison {
         negate = false
-        service_type {
-          operator = "EQUALS"
+        fast_string {
+          operator = "CONTAINS"
           values   = ["di-ipv-core-front"]
         }
       }


### PR DESCRIPTION
# Description:
Error in the comparison type being used, was using service_type and should be fast_string and switched from EQUALS to CONTAINS

## Ticket number:
PSREGOV-1416

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
