### PR TITLE
Changing to reference the new fog team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/observability @govuk-one-login/digital-identity-leads
+* @govuk-one-login/fog @govuk-one-login/digital-identity-leads


### PR DESCRIPTION
# Description:
Amending codeowners to instead reference the new fog team

## Ticket number:

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
