### PR TITLE
IPS-1212: Kiwi dashboards

### DIFF
--- a/dashboards/kiwi/bav-cri.json
+++ b/dashboards/kiwi/bav-cri.json
@@ -3,64 +3,25 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.293.129.20240615-053240"
+    "clusterVersion": "1.303.42.20241021-231645"
   },
   "dashboardMetadata": {
     "name": "KIWI - BAV",
     "shared": true,
     "owner": "madan.karuppiah@digital.cabinet-office.gov.uk",
-    "popularity": 3,
+    "tags": [
+      "KIWI"
+    ],
+    "popularity": 7,
     "hasConsistentColors": false
   },
   "tiles": [
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 0,
-        "left": 836,
-        "width": 342,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV ECS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4da27632-b4e2-4abe-bb50-c2c8c1270446)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 0,
-        "left": 418,
-        "width": 342,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV API Gateway Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=e64d7aae-f0b1-477e-9a95-a8d8a978f16e)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 0,
-        "left": 0,
-        "width": 342,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV Lambda Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=c12a984b-f5ea-4c25-9606-b6c9f15523b7)"
-    },
     {
       "name": "BAV Lambda Errors",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 76,
+        "top": 0,
         "left": 0,
         "width": 532,
         "height": 304
@@ -159,9 +120,9 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 76,
+        "top": 0,
         "left": 532,
-        "width": 1026,
+        "width": 950,
         "height": 304
       },
       "tileFilter": {},
@@ -271,9 +232,9 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 76,
-        "left": 1558,
-        "width": 418,
+        "top": 0,
+        "left": 1482,
+        "width": 570,
         "height": 304
       },
       "tileFilter": {},
@@ -370,12 +331,143 @@
       ]
     },
     {
+      "name": "Total Backend 5XX Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 912,
+        "left": 0,
+        "width": 380,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "metric": "cloud.aws.apigateway.5xxErrorByAccountIdApiNameRegion",
+          "spaceAggregation": "SUM",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiname"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "589782633452",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "141524324937",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "apiname",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "bav-cri-api - BAV Credential Issuer Private API",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "5XXError",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:apiname.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\")))):splitBy(\"aws.account.id\",apiname):sum:sort(value(sum,descending)):limit(20)):names"
+      ]
+    },
+    {
       "name": "Backend Requests",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 380,
-        "left": 304,
+        "top": 304,
+        "left": 380,
         "width": 722,
         "height": 304
       },
@@ -387,8 +479,10 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\"):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
@@ -463,7 +557,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(eq(\"aws.region\",eu-west-2)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\"):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -471,333 +565,23 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 0,
-        "left": 1254,
-        "width": 342,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV CloudFront Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=12d040b2-3461-4270-83aa-a3e8654fdc04)\n"
-    },
-    {
-      "name": "Backend Requests",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 380,
+        "top": 1216,
         "left": 0,
-        "width": 304,
+        "width": 380,
         "height": 304
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN",
-              "alias": "Request"
-            },
-            "seriesOverrides": [
-              {
-                "name": "f2f-cri-api - F2F Credential Issuer Private API",
-                "color": "#14a8f5"
-              },
-              {
-                "name": "Select series",
-                "color": "#dc172a"
-              },
-              {
-                "name": "Select series",
-                "color": "#ffee7c"
-              }
-            ]
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
-      ]
+      "markdown": "# Account IDs:\n\n\n## - BUILD: 141524324937\n## - STAGING: 589782633452\n## - INTEGRATION: 603505715695\n## - PRODUCTION: 096369912800"
     },
     {
-      "name": "Backend 4XX Error",
+      "name": "Total Backend Requests",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 684,
+        "top": 304,
         "left": 0,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": [
-              {
-                "name": "f2f-cri-api - F2F Credential Issuer Private API",
-                "color": "#fd8232"
-              },
-              {
-                "name": "Select series",
-                "color": "#5ead35"
-              },
-              {
-                "name": "Select series",
-                "color": "#14a8f5"
-              }
-            ]
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegionStage\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "Backend 5XX Errors",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 988,
-        "left": 0,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": [
-              {
-                "name": "f2f-cri-api - F2F Credential Issuer Private API",
-                "color": "#c9a000"
-              },
-              {
-                "name": "Select series",
-                "color": "#1f7e1e"
-              },
-              {
-                "name": "Select series",
-                "color": "#93060e"
-              }
-            ]
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "Backend 4xx Errors",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 684,
-        "left": 304,
-        "width": 722,
+        "width": 380,
         "height": 304
       },
       "tileFilter": {},
@@ -808,208 +592,17 @@
           "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Backend 5xx Errors",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 988,
-        "left": 304,
-        "width": 722,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "TURQUOISE",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameRegion\":filter(and(and(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Frontend Request",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 380,
-        "left": 1026,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
+        "type": "TABLE",
         "global": {},
         "rules": [
           {
@@ -1037,6 +630,7 @@
         "thresholds": [
           {
             "axisTarget": "LEFT",
+            "columnId": "Count",
             "rules": [
               {
                 "color": "#7dc540"
@@ -1048,708 +642,15 @@
                 "color": "#dc172a"
               }
             ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "Frontend 4xx Error",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 684,
-        "left": 1026,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "Frontend 5xx Error",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 988,
-        "left": 1026,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegion\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "ROYALBLUE",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": [
-              {
-                "name": "di-ipv-cri-f2f-front",
-                "color": "#ffe11c"
-              },
-              {
-                "name": "Select series",
-                "color": "#debbf3"
-              },
-              {
-                "name": "Select series",
-                "color": "#006d75"
-              }
-            ]
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegion\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegion\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy():sum:sort(value(sum,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "Frontend Requests",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 380,
-        "left": 1330,
-        "width": 646,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiid"
-          ],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "C:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):count:sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Frontend 4xx Errors",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 684,
-        "left": 1330,
-        "width": 646,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiid"
-          ],
-          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegionStage\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Frontend 5xx Errors",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 988,
-        "left": 1330,
-        "width": 646,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "apiid"
-          ],
-          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegionStage\":filter(and(and(eq(\"aws.account.id\",\"096369912800\")),and(eq(apiid,ubcq5mn6ha)),and(eq(\"aws.region\",eu-west-2)))):splitBy(apiid):sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Memory Utilisation",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1292,
-        "left": 1026,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV)),and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "CPU Utilisation by Service"
-            },
-            "seriesOverrides": [
-              {
-                "name": "Select series",
-                "color": "#ef651f"
-              },
-              {
-                "name": "Select series",
-                "color": "#ffee7c"
-              },
-              {
-                "name": "f2f-cri-front-F2FFrontEcsService-L7mJP36tBhG6",
-                "color": "#006bba"
-              }
-            ]
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "columnId": "MemoryUtilization (by ServiceName)",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "A",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV)),and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV)),and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "CPU Utilisation",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1292,
-        "left": 0,
-        "width": 304,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.ecs.containerinsights.cpuUtilizedByAccountIdClusterNameRegionServiceName:filter(and(and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu),and(eq(\"servicename\",\"bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_AREA",
-              "alias": "CPU Utilisation by Service"
-            },
-            "seriesOverrides": [
-              {
-                "name": "cic-cri-front-CICFrontEcsService-G7NkOt9sXyBp",
-                "color": "#4556d7"
-              },
-              {
-                "name": "ipvreturn-front-IPRFrontEcsService-7FAsrgigUrDQ",
-                "color": "#ffe11c"
-              },
-              {
-                "name": "f2f-cri-front-F2FFrontEcsService-L7mJP36tBhG6",
-                "color": "#9cd575"
-              }
-            ]
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "columnId": "CpuUtilized (by ServiceName)",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "A",
+            "queryId": "B",
             "visible": true
           }
         ],
         "tableSettings": {
           "hiddenColumns": [
-            "A:ServiceName.name"
+            "B:aws.account.id.name",
+            "B:apiid.name",
+            "B:apiname.name"
           ]
         },
         "graphChartSettings": {
@@ -1765,18 +666,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.ecs.containerinsights.cpuUtilizedByAccountIdClusterNameRegionServiceName:filter(and(and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu),and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.ecs.containerinsights.cpuUtilizedByAccountIdClusterNameRegionServiceName:filter(and(and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu),and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV))))):splitBy():sum:sort(value(sum,descending)):limit(20))"
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameRegion:filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
       ]
     },
     {
-      "name": "CPU Utilisation",
+      "name": "Total Frontend Requests",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1292,
-        "left": 304,
-        "width": 722,
+        "top": 304,
+        "left": 1102,
+        "width": 380,
         "height": 304
       },
       "tileFilter": {},
@@ -1784,70 +684,52 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "C",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.ecs.containerinsights.cpuUtilizedByAccountIdClusterNameRegionServiceName:filter(and(and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu),and(eq(\"servicename\",\"bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV\"))))):splitBy():sum:sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
-        "type": "STACKED_AREA",
+        "type": "TABLE",
         "global": {},
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "C:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
               "color": "DEFAULT",
-              "seriesType": "STACKED_AREA",
-              "alias": "CPU Utilisation by Service"
+              "seriesType": "COLUMN",
+              "alias": "Frontend Requests"
             },
-            "seriesOverrides": [
-              {
-                "name": "Select series",
-                "color": "#4556d7"
-              },
-              {
-                "name": "Select series",
-                "color": "#ffe11c"
-              },
-              {
-                "name": "Select series",
-                "color": "#9cd575"
-              }
-            ]
+            "seriesOverrides": []
           }
         ],
         "axes": {
           "xAxis": {
-            "displayName": "",
             "visible": true
           },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A"
-              ],
-              "defaultAxis": true
-            }
-          ]
+          "yAxes": []
         },
         "heatmapSettings": {
           "yAxis": "VALUE"
         },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
         "thresholds": [
           {
             "axisTarget": "LEFT",
-            "columnId": "MemoryUtilization (by ServiceName)",
+            "columnId": "",
             "rules": [
               {
                 "color": "#7dc540"
@@ -1859,12 +741,15 @@
                 "color": "#dc172a"
               }
             ],
-            "queryId": "A",
+            "queryId": "C",
             "visible": true
           }
         ],
         "tableSettings": {
-          "hiddenColumns": []
+          "hiddenColumns": [
+            "C:aws.account.id.name",
+            "C:apiid.name"
+          ]
         },
         "graphChartSettings": {
           "connectNulls": false
@@ -1879,17 +764,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.ecs.containerinsights.cpuUtilizedByAccountIdClusterNameRegionServiceName:filter(and(and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu),and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV))))):splitBy():sum:sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
       ]
     },
     {
-      "name": "Memory Utilisation",
+      "name": "Total Frontend 4xx Errors",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1292,
-        "left": 1330,
-        "width": 646,
+        "top": 608,
+        "left": 1102,
+        "width": 380,
         "height": 304
       },
       "tileFilter": {},
@@ -1897,11 +782,444 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "C",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV)),and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "4xx Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "C",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:aws.account.id.name",
+            "C:apiid.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "Memory",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1216,
+        "left": 1102,
+        "width": 380,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "clustername"
+          ],
+          "metricSelector": "cloud.aws.ecs.containerinsights.memoryUtilizedByAccountIdClusterNameRegionServiceName:filter(and(or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",clustername):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "clustername"
+          ],
+          "metricSelector": "cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",clustername):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Utilisation"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Utilised"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "MemoryUtilization",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:clustername.name",
+            "B:servicename.name",
+            "C:aws.account.id.name",
+            "D:aws.account.id.name",
+            "E:aws.account.id.name",
+            "E:servicename.name",
+            "D:clustername.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.ecs.containerinsights.memoryUtilizedByAccountIdClusterNameRegionServiceName:filter(and(or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",clustername):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names,(cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",clustername):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "Total Frontend 5xx Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 912,
+        "left": 1102,
+        "width": 380,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "4xx Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "C",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:aws.account.id.name",
+            "C:apiid.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "Total Backend 4xx Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 608,
+        "left": 0,
+        "width": 380,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "4xx Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "4XXError",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "C",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:aws.account.id.name",
+            "C:apiid.name",
+            "C:apiname.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameRegion\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "Memory Utilisation",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1216,
+        "left": 1482,
+        "width": 570,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.ecs.containerinsights.memoryUtilizedByAccountIdClusterNameRegionServiceName:filter(and(or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",clustername):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "clustername"
+          ],
+          "metricSelector": "cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",clustername):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
@@ -1911,28 +1229,26 @@
         "global": {},
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "B:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
               "color": "DEFAULT",
               "seriesType": "LINE",
-              "alias": "CPU Utilisation by Service"
+              "alias": "Utilised"
             },
-            "seriesOverrides": [
-              {
-                "name": "Select series",
-                "color": "#ef651f"
-              },
-              {
-                "name": "Select series",
-                "color": "#ffee7c"
-              },
-              {
-                "name": "Select series",
-                "color": "#006bba"
-              }
-            ]
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "TURQUOISE",
+              "seriesType": "LINE",
+              "alias": "Utilisation"
+            },
+            "seriesOverrides": []
           }
         ],
         "axes": {
@@ -1948,7 +1264,7 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A"
+                "C"
               ],
               "defaultAxis": true
             }
@@ -1992,22 +1308,574 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(and(eq(servicename,bav-cri-front-BAVFrontEcsService-6Q5wUnItFWBV)),and(eq(\"aws.region\",eu-west-2)),and(eq(clustername,bav-cri-front-BAVFrontEcsCluster-3u1erv0T6qCu)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.ecs.memoryUtilizationByAccountIdClusterNameRegionServiceName:filter(and(or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",clustername):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
+    },
+    {
+      "name": "Backend 5xx Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 912,
+        "left": 380,
+        "width": 722,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "COLUMN",
+              "alias": "5xx Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 1482,
+        "width": 570,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "COLUMN",
+              "alias": "Frontend requests"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "E"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:aws.account.id.name",
+            "C:apiid.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiIdRegion:filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend 5xx Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 912,
+        "left": 1482,
+        "width": 570,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"5xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "COLUMN",
+              "alias": "BUILD: 4xx Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:aws.account.id.name",
+            "C:apiid.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"5xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Backend 4XX Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 608,
+        "left": 380,
+        "width": 722,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ORANGE",
+              "seriesType": "COLUMN",
+              "alias": "Backend 4xx Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "4XXError",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,\"bav-cri-api - BAV Credential Issuer Private API\")),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",apiname):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Frontend 4xx Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 608,
+        "left": 1482,
+        "width": 570,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "apiid"
+          ],
+          "metricSelector": "cloud.aws.apigateway.\"4xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ORANGE",
+              "seriesType": "COLUMN",
+              "alias": "4xx Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:aws.account.id.name",
+            "C:apiid.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.\"4xxByAccountIdApiIdRegion\":filter(and(or(eq(apiid,q2a9wgfgne),eq(apiid,qknvpnkz5e),eq(apiid,j9rvmhb7ae),eq(apiid,ubcq5mn6ha)),or(eq(\"aws.account.id\",\"589782633452\"),eq(\"aws.account.id\",\"141524324937\"),eq(\"aws.account.id\",\"603505715695\"),eq(\"aws.account.id\",\"096369912800\")))):splitBy(\"aws.account.id\",apiid):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Links to further dashboards:",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 1216,
+        "left": 380,
+        "width": 722,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
     },
     {
       "name": "Markdown",
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 0,
-        "left": 1672,
-        "width": 342,
-        "height": 38
+        "top": 1254,
+        "left": 380,
+        "width": 722,
+        "height": 266
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV SQS Metrics](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=8cd69e4a-5911-47bd-87bb-7a8343c54189)\n"
+      "markdown": "## PROD\n- [APIGW](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=e64d7aae-f0b1-477e-9a95-a8d8a978f16e)\n- [Cloudfront](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=12d040b2-3461-4270-83aa-a3e8654fdc04)\n- [ECS](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=4da27632-b4e2-4abe-bb50-c2c8c1270446)\n- [SQS](https://bhe21058.live.dynatrace.com/#dashboard;gtf=-30d%20to%20now;gf=all;id=8cd69e4a-5911-47bd-87bb-7a8343c54189)"
     }
   ]
 }

--- a/dashboards/kiwi/bav-lambda-metrics.json
+++ b/dashboards/kiwi/bav-lambda-metrics.json
@@ -3,13 +3,16 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.293.129.20240615-053240"
+    "clusterVersion": "1.303.42.20241021-231645"
   },
   "dashboardMetadata": {
     "name": "KIWI - BAV - Lambda - Metrics",
     "shared": true,
     "owner": "madan.karuppiah@digital.cabinet-office.gov.uk",
-    "popularity": 1,
+    "tags": [
+      "KIWI"
+    ],
+    "popularity": 2,
     "hasConsistentColors": false
   },
   "tiles": [
@@ -388,565 +391,6 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "BAV-PartialNameMatch-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "metric": "builtin:cloud.aws.lambda.errors",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-PartialNameMatch-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_AREA",
-              "alias": "Invocations"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "STACKED_AREA",
-              "alias": "Errors"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Duration",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 418,
-        "left": 988,
-        "width": 494,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "metric": "builtin:cloud.aws.lambda.duration",
-          "spaceAggregation": "AVG",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-PartialNameMatch-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "metric": "builtin:cloud.aws.lambda.duration",
-          "spaceAggregation": "MIN",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-PartialNameMatch-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "metric": "builtin:cloud.aws.lambda.duration",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-PartialNameMatch-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_AREA",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_AREA",
-              "alias": "Average"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_AREA",
-              "alias": "Minimum"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "BLUE",
-              "seriesType": "STACKED_AREA",
-              "alias": "Maximum"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "columnId": "LambdaFunction code execution time.",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "A",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Concurrent Executions",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 418,
-        "left": 494,
-        "width": 494,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "metric": "builtin:cloud.aws.lambda.concExecutions",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-PartialNameMatch-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "metric": "builtin:cloud.aws.lambda.throttlers",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-PartialNameMatch-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "LINE",
-              "alias": "Concurrent Executions"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "LINE",
-              "alias": "Throttles"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Invocations and Errors",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 798,
-        "left": 0,
-        "width": 494,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "metric": "builtin:cloud.aws.lambda.invocations",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
                     "value": "BAV-Person-Info-Key-bav-cri-api",
                     "evaluator": "IN",
                     "matchExactly": true
@@ -1090,7 +534,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 798,
+        "top": 418,
         "left": 988,
         "width": 494,
         "height": 342
@@ -1307,7 +751,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 798,
+        "top": 418,
         "left": 494,
         "width": 494,
         "height": 342
@@ -1478,7 +922,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1178,
+        "top": 798,
         "left": 0,
         "width": 494,
         "height": 342
@@ -1649,7 +1093,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1178,
+        "top": 798,
         "left": 988,
         "width": 494,
         "height": 342
@@ -1866,7 +1310,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1178,
+        "top": 798,
         "left": 494,
         "width": 494,
         "height": 342
@@ -2037,7 +1481,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1558,
+        "top": 1178,
         "left": 0,
         "width": 494,
         "height": 342
@@ -2208,7 +1652,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1558,
+        "top": 1178,
         "left": 988,
         "width": 494,
         "height": 342
@@ -2425,7 +1869,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1558,
+        "top": 1178,
         "left": 494,
         "width": 494,
         "height": 342
@@ -2596,7 +2040,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1938,
+        "top": 1558,
         "left": 0,
         "width": 494,
         "height": 342
@@ -2767,7 +2211,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1938,
+        "top": 1558,
         "left": 988,
         "width": 494,
         "height": 342
@@ -2984,7 +2428,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1938,
+        "top": 1558,
         "left": 494,
         "width": 494,
         "height": 342
@@ -3155,7 +2599,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2318,
+        "top": 1938,
         "left": 0,
         "width": 494,
         "height": 342
@@ -3326,7 +2770,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2318,
+        "top": 1938,
         "left": 988,
         "width": 494,
         "height": 342
@@ -3543,7 +2987,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2318,
+        "top": 1938,
         "left": 494,
         "width": 494,
         "height": 342
@@ -3714,566 +3158,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2698,
-        "left": 0,
-        "width": 494,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "metric": "builtin:cloud.aws.lambda.invocations",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-person-info-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "metric": "builtin:cloud.aws.lambda.errors",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-person-info-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_AREA",
-              "alias": "Invocations"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "STACKED_AREA",
-              "alias": "Errors"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-person-info-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-person-info-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Duration",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2698,
-        "left": 988,
-        "width": 494,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "metric": "builtin:cloud.aws.lambda.duration",
-          "spaceAggregation": "AVG",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-person-info-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "metric": "builtin:cloud.aws.lambda.duration",
-          "spaceAggregation": "MIN",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-person-info-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "metric": "builtin:cloud.aws.lambda.duration",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-person-info-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_AREA",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "STACKED_AREA",
-              "alias": "Average"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "STACKED_AREA",
-              "alias": "Minimum"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "BLUE",
-              "seriesType": "STACKED_AREA",
-              "alias": "Maximum"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "columnId": "LambdaFunction code execution time.",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "A",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-person-info-bav-cri-api~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-person-info-bav-cri-api~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-person-info-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Concurrent Executions",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2698,
-        "left": 494,
-        "width": 494,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "metric": "builtin:cloud.aws.lambda.concExecutions",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-person-info-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "metric": "builtin:cloud.aws.lambda.throttlers",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "sortBy": "DESC",
-          "sortByDimension": "",
-          "filterBy": {
-            "filterOperator": "AND",
-            "nestedFilters": [
-              {
-                "filter": "dt.entity.aws_lambda_function",
-                "filterType": "NAME",
-                "filterOperator": "OR",
-                "entityAttribute": "entityName",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "BAV-person-info-bav-cri-api",
-                    "evaluator": "IN",
-                    "matchExactly": true
-                  }
-                ]
-              }
-            ],
-            "criteria": []
-          },
-          "limit": 20,
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "LINE",
-              "alias": "Concurrent Executions"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "LINE",
-              "alias": "Throttles"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-person-info-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-person-info-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Invocations and Errors",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3078,
+        "top": 2318,
         "left": 0,
         "width": 494,
         "height": 342
@@ -4444,7 +3329,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3078,
+        "top": 2318,
         "left": 988,
         "width": 494,
         "height": 342
@@ -4661,7 +3546,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3078,
+        "top": 2318,
         "left": 494,
         "width": 494,
         "height": 342
@@ -4832,7 +3717,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3838,
+        "top": 3078,
         "left": 0,
         "width": 494,
         "height": 342
@@ -5003,7 +3888,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3838,
+        "top": 3078,
         "left": 988,
         "width": 494,
         "height": 342
@@ -5220,7 +4105,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3838,
+        "top": 3078,
         "left": 494,
         "width": 494,
         "height": 342
@@ -5391,7 +4276,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3458,
+        "top": 2698,
         "left": 0,
         "width": 494,
         "height": 342
@@ -5562,7 +4447,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3458,
+        "top": 2698,
         "left": 494,
         "width": 494,
         "height": 342
@@ -5733,7 +4618,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3458,
+        "top": 2698,
         "left": 988,
         "width": 494,
         "height": 342
@@ -6174,7 +5059,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Session Function - [Dashboard]()"
+      "markdown": "## Session Function"
     },
     {
       "name": "Markdown",
@@ -6188,7 +5073,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Partial Name Match Function - [Dashboard]()"
+      "markdown": "## PersonInfoKey Function"
     },
     {
       "name": "Markdown",
@@ -6202,7 +5087,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Person Info Key Function - [Dashboard]()"
+      "markdown": "## UserInfo Function"
     },
     {
       "name": "Markdown",
@@ -6216,7 +5101,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## UserInfo Function - [Dashboard]()"
+      "markdown": "## PersonInfo Function"
     },
     {
       "name": "Markdown",
@@ -6230,7 +5115,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## PersonInfo Function - [Dashboard]()"
+      "markdown": "## Access Token Function"
     },
     {
       "name": "Markdown",
@@ -6244,7 +5129,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Access Token Function - [Dashboard]()"
+      "markdown": "## HmrcToken Function"
     },
     {
       "name": "Markdown",
@@ -6258,7 +5143,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Hmrc Token Function - [Dashboard](https://bhe21058.live.dynatrace.com/ui/entity/SERVICE-CC98F53DFCB64F6B?gtf=-30d%20to%20now&gf=all&sessionId=JcDODSPsM3HVKhUz)"
+      "markdown": "## JsonWebKeys Function"
     },
     {
       "name": "Markdown",
@@ -6272,7 +5157,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Person Info Function - [Dashboard]()"
+      "markdown": "## Verify Account Function"
     },
     {
       "name": "Markdown",
@@ -6286,7 +5171,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## JsonWebKeys Function - [Dashboard](https://bhe21058.live.dynatrace.com/ui/entity/SERVICE-3178D3D5CBDD5379?gtf=-2h&gf=all&sessionId=brXEADOdgVKbu1od)"
+      "markdown": "## Abort Function"
     },
     {
       "name": "Markdown",
@@ -6300,21 +5185,566 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Verify Account  Function - [Dashboard]()"
+      "markdown": "## Partial Name Match Function"
     },
     {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
+      "name": "Concurrent Executions",
+      "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3800,
-        "left": 0,
-        "width": 608,
-        "height": 38
+        "top": 3458,
+        "left": 494,
+        "width": 494,
+        "height": 342
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Abort Function - [Dashboard]()"
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "builtin:cloud.aws.lambda.concExecutions",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "dt.entity.aws_lambda_function",
+                "filterType": "NAME",
+                "filterOperator": "OR",
+                "entityAttribute": "entityName",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "BAV-PartialNameMatch-bav-cri-api",
+                    "evaluator": "IN",
+                    "matchExactly": true
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "metric": "builtin:cloud.aws.lambda.throttlers",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "dt.entity.aws_lambda_function",
+                "filterType": "NAME",
+                "filterOperator": "OR",
+                "entityAttribute": "entityName",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "BAV-PartialNameMatch-bav-cri-api",
+                    "evaluator": "IN",
+                    "matchExactly": true
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Concurrent Executions"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Throttles"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Duration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3458,
+        "left": 988,
+        "width": 494,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "builtin:cloud.aws.lambda.duration",
+          "spaceAggregation": "AVG",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "dt.entity.aws_lambda_function",
+                "filterType": "NAME",
+                "filterOperator": "OR",
+                "entityAttribute": "entityName",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "BAV-PartialNameMatch-bav-cri-api",
+                    "evaluator": "IN",
+                    "matchExactly": true
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "metric": "builtin:cloud.aws.lambda.duration",
+          "spaceAggregation": "MIN",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "dt.entity.aws_lambda_function",
+                "filterType": "NAME",
+                "filterOperator": "OR",
+                "entityAttribute": "entityName",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "BAV-PartialNameMatch-bav-cri-api",
+                    "evaluator": "IN",
+                    "matchExactly": true
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "metric": "builtin:cloud.aws.lambda.duration",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "dt.entity.aws_lambda_function",
+                "filterType": "NAME",
+                "filterOperator": "OR",
+                "entityAttribute": "entityName",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "BAV-PartialNameMatch-bav-cri-api",
+                    "evaluator": "IN",
+                    "matchExactly": true
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_AREA",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_AREA",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "STACKED_AREA",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "STACKED_AREA",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Invocations and Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3458,
+        "left": 0,
+        "width": 494,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "builtin:cloud.aws.lambda.invocations",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "dt.entity.aws_lambda_function",
+                "filterType": "NAME",
+                "filterOperator": "OR",
+                "entityAttribute": "entityName",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "BAV-PartialNameMatch-bav-cri-api",
+                    "evaluator": "IN",
+                    "matchExactly": true
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "metric": "builtin:cloud.aws.lambda.errors",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "dt.entity.aws_lambda_function",
+                "filterType": "NAME",
+                "filterOperator": "OR",
+                "entityAttribute": "entityName",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "BAV-PartialNameMatch-bav-cri-api",
+                    "evaluator": "IN",
+                    "matchExactly": true
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "STACKED_AREA",
+              "alias": "Invocations"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "STACKED_AREA",
+              "alias": "Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"BAV-PartialNameMatch-bav-cri-api~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
     }
   ]
 }

--- a/dashboards/kiwi/sqs-metrics.json
+++ b/dashboards/kiwi/sqs-metrics.json
@@ -3,60 +3,433 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.293.129.20240615-053240"
+    "clusterVersion": "1.303.42.20241021-231645"
   },
   "dashboardMetadata": {
     "name": "KIWI - SQS - Metrics",
-    "shared": false,
+    "shared": true,
     "owner": "madan.karuppiah@digital.cabinet-office.gov.uk",
+
+    "tags": [
+      "KIWI"
+    ],
     "popularity": 1,
     "hasConsistentColors": false
   },
   "tiles": [
     {
-      "name": "F2F TxMA DLQ",
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "# BAV"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 76,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 494,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## PartialMatches SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 3610,
+        "left": 0,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "# IPVReturn"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 3686,
+        "left": 2052,
+        "width": 494,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 3686,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 4104,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## GovNotify SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1102,
+        "left": 2052,
+        "width": 494,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1102,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1026,
+        "left": 0,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "# CIC"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1634,
+        "left": 0,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "# F2F"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1710,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1710,
+        "left": 2052,
+        "width": 494,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 4104,
+        "left": 2052,
+        "width": 494,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## GovNotify DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 2964,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## YotiCallback SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 2964,
+        "left": 2052,
+        "width": 608,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## YotiCallback DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 2546,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## GovNotify SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 2546,
+        "left": 2052,
+        "width": 608,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## GovNotify DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 2128,
+        "left": 2052,
+        "width": 608,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## IPVCore DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 2128,
+        "left": 0,
+        "width": 2052,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## IPVCore SQS"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 76,
+        "left": 2052,
+        "width": 494,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## TxMA DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 494,
+        "left": 2052,
+        "width": 494,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## PartialNameMatch DLQ"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 684,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Account IDs:\n\nBUILD: 576724867321\nSTAGING: 589782633452"
+    },
+    {
+      "name": "BAV TxMA: Messages Received and Sent",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 114,
-        "left": 1254,
-        "width": 494,
+        "left": 0,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "customName": "Single value",
+      "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "H",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-TxMASQSQueueDeadLetterQueue-pzKWEkMEmX8j\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "H:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
             "properties": {
-              "color": "DEFAULT"
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Received"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Sent"
             },
             "seriesOverrides": []
           }
         ],
         "axes": {
           "xAxis": {
+            "displayName": "",
             "visible": true
           },
-          "yAxes": []
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "H",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
         },
         "heatmapSettings": {
-          "yAxis": "VALUE"
+          "yAxis": "VALUE",
+          "showLabels": false
         },
         "singleValueSettings": {
           "showTrend": true,
@@ -96,18 +469,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueueDeadLetterQueue-pzKWEkMEmX8j)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueueDeadLetterQueue-pzKWEkMEmX8j)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "F2F TxMA SQS",
+      "name": "BAV TxMA: Approx. Number of Messages Delayed and Not Visible",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 114,
-        "left": 0,
-        "width": 646,
+        "left": 684,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -115,47 +487,279 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "D",
+          "metric": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "141524324937",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "bav-cri-api-TxMASQSQueue-DJ0SDVLoOH0i",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "E",
+          "metric": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "bav-cri-api-TxMASQSQueue-DJ0SDVLoOH0i",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "141524324937",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "G",
+          "metric": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "589782633452",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "bav-cri-api-TxMASQSQueue-4XPzZQM7fCiY",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "H",
+          "metric": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "bav-cri-api-TxMASQSQueue-4XPzZQM7fCiY",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "589782633452",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
         {
-          "id": "B",
+          "id": "J",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "D:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "YELLOW",
+              "color": "DEFAULT",
               "seriesType": "COLUMN",
-              "alias": "Messages Received"
+              "alias": "BUILD: Not Visible"
             },
             "seriesOverrides": []
           },
           {
-            "matcher": "B:",
+            "matcher": "E:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "RED",
+              "color": "DEFAULT",
               "seriesType": "COLUMN",
-              "alias": "Messages Sent"
+              "alias": "BUILD: Delayed"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "G:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "STAGING: Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "H:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "STAGING: Delayed"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "J:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Delayed"
             },
             "seriesOverrides": []
           }
@@ -173,8 +777,12 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
+                "D",
+                "E",
+                "G",
+                "H",
+                "I",
+                "J"
               ],
               "defaultAxis": true
             }
@@ -183,11 +791,6 @@
         "heatmapSettings": {
           "yAxis": "VALUE",
           "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
         },
         "thresholds": [
           {
@@ -222,104 +825,274 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "F2F IPVCore DLQ",
+      "name": "BAV TxMA: Approx. Age of Oldest Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 114,
+        "left": 1368,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "I",
+          "metric": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "589782633452",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "bav-cri-api-TxMASQSQueue-4XPzZQM7fCiY",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "BUILD: ApproximateAgeOfOldestMessage"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "STAGING: ApproximateAgeOfOldestMessage"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "F",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "BAV TxMA: Messages Received by DLQ",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 114,
+        "left": 2052,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-TxMASQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "BAV PartialMatches: Messages Received and Sent",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 532,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-IPVCoreDeadLetterQueue-hGpdWNhpLACL\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-IPVCoreDeadLetterQueue-hGpdWNhpLACL)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-IPVCoreDeadLetterQueue-hGpdWNhpLACL)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "F2F IPVCore SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 532,
         "left": 0,
-        "width": 646,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -327,1147 +1100,67 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "D",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
         {
-          "id": "B",
+          "id": "E",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "F2F YotiCallback DLQ",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 950,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-YotiCallbackQueueDeadLetterQueue-7G919Zzha88n\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-YotiCallbackQueueDeadLetterQueue-7G919Zzha88n)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-YotiCallbackQueueDeadLetterQueue-7G919Zzha88n)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "F2F YotiCallback SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 950,
-        "left": 0,
-        "width": 646,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "TURQUOISE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "F2F GovNotify SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1368,
-        "left": 0,
-        "width": 646,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "COLUMN",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Gov NotifyDLQ",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1368,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-GovNotifySQSQueueDeadLetterQueue-gc6pf7suaVjm\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-GovNotifySQSQueueDeadLetterQueue-gc6pf7suaVjm)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-GovNotifySQSQueueDeadLetterQueue-gc6pf7suaVjm)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "CIC TxMA SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1824,
-        "left": 0,
-        "width": 646,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "COLUMN",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "CIC TxMA DLQ",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1824,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"cic-cri-api-TxMASQSQueueDeadLetterQueue-JhJeqd7rvD7o\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,cic-cri-api-TxMASQSQueueDeadLetterQueue-JhJeqd7rvD7o)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,cic-cri-api-TxMASQSQueueDeadLetterQueue-JhJeqd7rvD7o)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "IPVReturn TxMA SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2280,
-        "left": 0,
-        "width": 646,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "TURQUOISE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "IPVReturn TxMA DLQ",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2280,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-TxMASQSQueueDeadLetterQueue-ylrjKHvNbj2y\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-TxMASQSQueueDeadLetterQueue-ylrjKHvNbj2y)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-TxMASQSQueueDeadLetterQueue-ylrjKHvNbj2y)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "IPVReturn GovNotify SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2698,
-        "left": 0,
-        "width": 646,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "BAV TxMA SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3154,
-        "left": 0,
-        "width": 646,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-TxMASQSQueue-boXh5r69P1Q2\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-TxMASQSQueue-boXh5r69P1Q2\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
+            "matcher": "D:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
               "color": "ROYALBLUE",
               "seriesType": "COLUMN",
-              "alias": "Messages Sent"
+              "alias": "Received"
             },
-            "seriesOverrides": []
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#c396e0"
+              }
+            ]
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "COLUMN",
+              "alias": "Sent"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#00a1b2"
+              }
+            ]
           }
         ],
         "axes": {
@@ -1483,8 +1176,8 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
+                "D",
+                "E"
               ],
               "defaultAxis": true
             }
@@ -1532,866 +1225,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-TxMASQSQueue-boXh5r69P1Q2)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-TxMASQSQueue-boXh5r69P1Q2)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "BAV TxMA DLQ",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3154,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-TxMASQSQueueDeadLetterQueue-XfBCUscwU4iD\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-TxMASQSQueueDeadLetterQueue-XfBCUscwU4iD)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-TxMASQSQueueDeadLetterQueue-XfBCUscwU4iD)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "BAV Partial Name Match SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3572,
-        "left": 0,
-        "width": 646,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "COLUMN",
-              "alias": "Messages Received"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Sent"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "BAV Partial Name Match  GovNotify DLQ",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3572,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-PartialNameMatchQueueDeadLetterQueue-MB2x8tadumRE\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-PartialNameMatchQueueDeadLetterQueue-MB2x8tadumRE)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-PartialNameMatchQueueDeadLetterQueue-MB2x8tadumRE)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "IPVReturn GovNotify DLQ",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2698,
-        "left": 1254,
-        "width": 494,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-GovNotifySQSQueueDeadLetterQueue-yNsuZ175RfiX\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-GovNotifySQSQueueDeadLetterQueue-yNsuZ175RfiX)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names",
-        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-GovNotifySQSQueueDeadLetterQueue-yNsuZ175RfiX)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20))"
-      ]
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 38,
-        "left": 646,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [F2F SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails;id=CUSTOM_DEVICE_GROUP-4435BF8979DC15AB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 76,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-75B71AD14FD3B7E6;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 76,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-CC4C6AB0550572DB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 494,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVCore SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-2A670E585F8BA245;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 494,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVCore DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-CC4C6AB0550572DB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 912,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [YotiCallback SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-C694A458A88147C2;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 912,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-CC4C6AB0550572DB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 1330,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [GovNotify SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-296DAEF5FEFF8C43;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 1330,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [GovNotify DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-03A4C8C5DDCBFFB4;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 1748,
-        "left": 646,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [CIC SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails;id=CUSTOM_DEVICE_GROUP-4435BF8979DC15AB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 1786,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-75B71AD14FD3B7E6;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 1786,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-CC4C6AB0550572DB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 2204,
-        "left": 646,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [IPVReturn SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails;id=CUSTOM_DEVICE_GROUP-4435BF8979DC15AB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 2242,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-75B71AD14FD3B7E6;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 2242,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-CC4C6AB0550572DB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 2660,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [GovNotify SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-A63FC8DCA1C359C5;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 2660,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [GovNotify DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-CC4C6AB0550572DB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 3078,
-        "left": 646,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [BAV SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails;id=CUSTOM_DEVICE_GROUP-48BC089CDCE0C309;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 3116,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-6DAE8F9981693856;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 3116,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [TxMA DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-2E5891683996FE52;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 3534,
-        "left": 0,
-        "width": 608,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [GovNotify SQS Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-A63FC8DCA1C359C5;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
-        "top": 3534,
-        "left": 1254,
-        "width": 494,
-        "height": 38
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "## [PartialName DLQ Dashboard](https://bhe21058.live.dynatrace.com/#customdevicegroupdetails/entity;id=CUSTOM_DEVICE-CC4C6AB0550572DB;gtf=-30d%20to%20now;gf=all)\n"
-    },
-    {
-      "name": "F2F TxMA SQS",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 114,
-        "left": 646,
-        "width": 608,
-        "height": 380
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-TxMASQSQueue-dUHIGJZSvY5b)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
-      ]
-    },
-    {
-      "name": "F2F IPVCore SQS",
+      "name": "BAV PartialMatches: Approx. Number of Messages Delayed and Not Visible",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 532,
-        "left": 646,
-        "width": 608,
+        "left": 684,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -2399,66 +1243,55 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "D",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
         {
-          "id": "B",
+          "id": "E",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "D:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "TURQUOISE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Not Visible"
             },
             "seriesOverrides": []
           },
           {
-            "matcher": "B:",
+            "matcher": "E:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "GREEN",
-              "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Delayed"
             },
             "seriesOverrides": []
           }
@@ -2476,19 +1309,10 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
+                "D",
+                "E",
+                "G",
+                "H"
               ],
               "defaultAxis": true
             }
@@ -2497,11 +1321,6 @@
         "heatmapSettings": {
           "yAxis": "VALUE",
           "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
         },
         "thresholds": [
           {
@@ -2536,17 +1355,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-IPVCoreSQSQueue-CPbnPGKq0SL7)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "F2F YotiCallback SQS",
+      "name": "BAV PartialMatches: Approx. Age of Oldest Message",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 950,
-        "left": 646,
-        "width": 608,
+        "top": 532,
+        "left": 1368,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -2554,66 +1373,84 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "I",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
         {
-          "id": "B",
+          "id": "J",
+          "metric": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "queuename",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "bav-cri-api-PartialMatchesQueue-QAtG6pkduyZs",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "141524324937",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
           "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
+          "enabled": false
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "I:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "STAGING: ApproximateAgeOfOldestMessage"
             },
             "seriesOverrides": []
           },
           {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
+            "matcher": "J:",
             "properties": {
-              "color": "GREEN",
-              "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
+              "color": "DEFAULT"
             },
             "seriesOverrides": []
           }
@@ -2631,19 +1468,7 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
+                "I"
               ],
               "defaultAxis": true
             }
@@ -2652,11 +1477,6 @@
         "heatmapSettings": {
           "yAxis": "VALUE",
           "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
         },
         "thresholds": [
           {
@@ -2691,122 +1511,56 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-YotiCallbackQueue-EjcZqZs0E2iN)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialMatchesQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "F2F GovNotify SQS",
+      "name": "BAV PartialNameMatches: Messages Received by DLQ",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1368,
-        "left": 646,
+        "top": 532,
+        "left": 2052,
         "width": 608,
         "height": 380
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
+      "customName": "Single value",
       "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
         {
           "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialNameMatchQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
-        "type": "GRAPH_CHART",
+        "type": "TABLE",
         "global": {},
         "rules": [
           {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
-            },
-            "seriesOverrides": []
-          },
-          {
             "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
             "properties": {
-              "color": "GREEN",
-              "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
+              "color": "DEFAULT"
             },
             "seriesOverrides": []
           }
         ],
         "axes": {
           "xAxis": {
-            "displayName": "",
             "visible": true
           },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
+          "yAxes": []
         },
         "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
+          "yAxis": "VALUE"
         },
         "singleValueSettings": {
           "showTrend": true,
@@ -2816,6 +1570,7 @@
         "thresholds": [
           {
             "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
             "rules": [
               {
                 "color": "#7dc540"
@@ -2827,11 +1582,17 @@
                 "color": "#dc172a"
               }
             ],
+            "queryId": "B",
             "visible": true
           }
         ],
         "tableSettings": {
-          "hiddenColumns": []
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
         },
         "graphChartSettings": {
           "connectNulls": false
@@ -2846,17 +1607,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,f2f-cri-api-GovNotifySQSQueue-rc0vsUWFF6Da)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,bav-cri-api-PartialNameMatchQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"576724867321\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
       ]
     },
     {
-      "name": "CIC TxMA SQS",
+      "name": "CIC TxMA: Messages Received and Sent",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1824,
-        "left": 646,
-        "width": 608,
+        "top": 1140,
+        "left": 0,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -2864,68 +1625,67 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "F",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,\"cic-cri-api-TxMASQSQueue-\")),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
         {
-          "id": "B",
+          "id": "G",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,\"cic-cri-api-TxMASQSQueue-\")),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "F:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "PURPLE",
+              "color": "ORANGE",
               "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
+              "alias": "Received"
             },
-            "seriesOverrides": []
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#2ab06f"
+              }
+            ]
           },
           {
-            "matcher": "B:",
+            "matcher": "G:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "GREEN",
+              "color": "DEFAULT",
               "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
+              "alias": "Sent"
             },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
-            },
-            "seriesOverrides": []
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#99dea8"
+              }
+            ]
           }
         ],
         "axes": {
@@ -2941,19 +1701,10 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
+                "D",
+                "E",
+                "F",
+                "G"
               ],
               "defaultAxis": true
             }
@@ -3001,17 +1752,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,cic-cri-api-TxMASQSQueue-EsrY58bqzoRQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,cic-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,cic-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "IPVReturn TxMA SQS",
+      "name": "CIC TxMA: Approximate Number of Messages Delayed and Not Visible",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2280,
-        "left": 646,
-        "width": 608,
+        "top": 1140,
+        "left": 684,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -3019,66 +1770,55 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "G",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,cic-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
         {
-          "id": "B",
+          "id": "H",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,\"cic-cri-api-TxMASQSQueue-\")),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "G:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "PURPLE",
+              "color": "DEFAULT",
               "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
+              "alias": "Not Visible"
             },
             "seriesOverrides": []
           },
           {
-            "matcher": "B:",
+            "matcher": "H:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "GREEN",
+              "color": "DEFAULT",
               "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
+              "alias": "Delayed"
             },
             "seriesOverrides": []
           }
@@ -3096,19 +1836,10 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
+                "D",
+                "E",
+                "G",
+                "H"
               ],
               "defaultAxis": true
             }
@@ -3117,11 +1848,6 @@
         "heatmapSettings": {
           "yAxis": "VALUE",
           "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
         },
         "thresholds": [
           {
@@ -3156,17 +1882,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-TxMASQSQueue-BxRz0Nm7qph3)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,cic-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,cic-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "IPVReturn GovNotify SQS",
+      "name": "CIC TxMA: Approximate Age of Oldest Message",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2698,
-        "left": 646,
-        "width": 608,
+        "top": 1140,
+        "left": 1368,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -3174,66 +1900,32 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "F",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,\"cic-cri-api-TxMASQSQueue-\")),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "F:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "GREEN",
-              "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Age of Oldest Message"
             },
             "seriesOverrides": []
           }
@@ -3251,19 +1943,8 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
+                "F",
+                "I"
               ],
               "defaultAxis": true
             }
@@ -3272,11 +1953,6 @@
         "heatmapSettings": {
           "yAxis": "VALUE",
           "showLabels": false
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
         },
         "thresholds": [
           {
@@ -3311,122 +1987,56 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,ipvreturn-api-GovNotifySQSQueue-unIwMtFgkERQ)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,cic-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
     },
     {
-      "name": "BAV TxMA SQS",
+      "name": "CIC TxMA: Messages Received by DLQ",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3154,
-        "left": 646,
+        "top": 1140,
+        "left": 2052,
         "width": 608,
         "height": 380
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
+      "customName": "Single value",
       "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-TxMASQSQueue-boXh5r69P1Q2\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
         {
           "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-TxMASQSQueue-boXh5r69P1Q2\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-TxMASQSQueue-boXh5r69P1Q2\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,\"cic-cri-api-TxMASQSQueueDeadLetterQueue-\")),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
-        "type": "GRAPH_CHART",
+        "type": "TABLE",
         "global": {},
         "rules": [
           {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "PURPLE",
-              "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
-            },
-            "seriesOverrides": []
-          },
-          {
             "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
             "properties": {
-              "color": "GREEN",
-              "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
+              "color": "DEFAULT"
             },
             "seriesOverrides": []
           }
         ],
         "axes": {
           "xAxis": {
-            "displayName": "",
             "visible": true
           },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
+          "yAxes": []
         },
         "heatmapSettings": {
-          "yAxis": "VALUE",
-          "showLabels": false
+          "yAxis": "VALUE"
         },
         "singleValueSettings": {
           "showTrend": true,
@@ -3436,6 +2046,7 @@
         "thresholds": [
           {
             "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
             "rules": [
               {
                 "color": "#7dc540"
@@ -3447,11 +2058,17 @@
                 "color": "#dc172a"
               }
             ],
+            "queryId": "B",
             "visible": true
           }
         ],
         "tableSettings": {
-          "hiddenColumns": []
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
         },
         "graphChartSettings": {
           "connectNulls": false
@@ -3466,17 +2083,17 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-TxMASQSQueue-boXh5r69P1Q2)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-TxMASQSQueue-boXh5r69P1Q2)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-TxMASQSQueue-boXh5r69P1Q2)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,cic-cri-api-TxMASQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"060113405249\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
       ]
     },
     {
-      "name": "BAV Partial Name Match  GovNotify SQS",
+      "name": "IPVReturn TxMA: Messages Received and Sent",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 3572,
-        "left": 646,
-        "width": 608,
+        "top": 3724,
+        "left": 0,
+        "width": 684,
         "height": 380
       },
       "tileFilter": {},
@@ -3484,68 +2101,62 @@
       "customName": "Data explorer results",
       "queries": [
         {
-          "id": "A",
+          "id": "D",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         },
         {
-          "id": "B",
+          "id": "E",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [],
-          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,\"bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze\")),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
-            "matcher": "A:",
+            "matcher": "D:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "PURPLE",
+              "color": "DEFAULT",
               "seriesType": "COLUMN",
-              "alias": "Messages Delayed"
+              "alias": "Received"
             },
             "seriesOverrides": []
           },
           {
-            "matcher": "B:",
+            "matcher": "E:",
             "unitTransform": "auto",
             "valueFormat": "auto",
             "properties": {
-              "color": "GREEN",
+              "color": "BLUE",
               "seriesType": "COLUMN",
-              "alias": "Messages Not Visible"
+              "alias": "Sent"
             },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "YELLOW",
-              "seriesType": "LINE"
-            },
-            "seriesOverrides": []
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#00a1b2"
+              }
+            ]
           }
         ],
         "axes": {
@@ -3561,19 +2172,8 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "A",
-                "B"
-              ],
-              "defaultAxis": true
-            },
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "RIGHT",
-              "queryIds": [
-                "C"
+                "D",
+                "E"
               ],
               "defaultAxis": true
             }
@@ -3621,8 +2221,2754 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(eq(queuename,bav-cri-api-PartialMatchesQueue-2fJLDoaaWaze)),or(eq(\"aws.region\",eu-west-2)))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
       ]
+    },
+    {
+      "name": "IPVReturn TxMA: Approx. Number of Messages Delayed and Not Visible",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3724,
+        "left": 684,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Delayed"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "IPVReturn TxMA: Approx. Age of Oldest Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3724,
+        "left": 1368,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Age of Oldest Message"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "F",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "IPVReturn TxMA: Messages Received by DLQ",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3724,
+        "left": 2052,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-TxMASQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "IPVReturn GovNotify: Messages Received and Sent",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4142,
+        "left": 0,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "COLUMN",
+              "alias": "Received"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#c396e0"
+              }
+            ]
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "COLUMN",
+              "alias": "Sent"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#00a1b2"
+              }
+            ]
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E",
+                "F",
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "IPVReturn GovNotify: Approx. Number of Messages Delayed and Not Visible",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4142,
+        "left": 684,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Delayed"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E",
+                "G",
+                "H"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "IPVReturn GovNotify: Approx. Age of Oldest Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4142,
+        "left": 1368,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Age of Oldest Message"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "I",
+                "J"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "IPVReturn GovNotify:  Messages Received by DLQ",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4142,
+        "left": 2052,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Messages Received"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,ipvreturn-api-GovNotifySQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"489145412748\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "F2F TxMA: Messages Received and Sent",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 0,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "H",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "H:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Received"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Sent"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "H",
+                "I",
+                "F",
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F TxMA: Approximate Number of Messages Delayed and Not Visible",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 684,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "J",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "J:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Delayed"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "I",
+                "J",
+                "G",
+                "H"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F TxMA: Approximate Age of Oldest Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 1368,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "BUILD: ApproximateAgeOfOldestMessage"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "F",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F TxMA: Messages Received by DLQ",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 2052,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-TxMASQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "F2F IPVCore: Messages Received and Sent",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2166,
+        "left": 0,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "COLUMN",
+              "alias": "Received"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#c396e0"
+              }
+            ]
+          },
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ORANGE",
+              "seriesType": "COLUMN",
+              "alias": "Sent"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#2ab06f"
+              }
+            ]
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E",
+                "F",
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F IPVCore: Approx. Number of Messages Delayed and Not Visible",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2166,
+        "left": 684,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Delayed"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E",
+                "G",
+                "H"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F IPVCore: Approx. Age of Oldest Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2166,
+        "left": 1368,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "BUILD: Age of Oldest Message"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "I",
+                "J"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreSQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F IPVCore:  Messages Received by DLQ",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2166,
+        "left": 2052,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-IPVCoreDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "F2F GovNotify: Messages Received and Sent",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2584,
+        "left": 0,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "COLUMN",
+              "alias": "Received"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#c396e0"
+              }
+            ]
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "COLUMN",
+              "alias": "Sent"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#00a1b2"
+              }
+            ]
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E",
+                "F",
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F GovNotify: Approx. Number of Messages Delayed and Not Visible",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2584,
+        "left": 684,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Delayed"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F GovNotify: Approx. Age of Oldest Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2584,
+        "left": 1368,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Age of Oldest Message"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "I",
+                "J"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F GovNotify:  Messages Received by DLQ",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2584,
+        "left": 2052,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-GovNotifySQSQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "F2F YotiCallback: Messages Received and Sent",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3002,
+        "left": 0,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ROYALBLUE",
+              "seriesType": "COLUMN",
+              "alias": "Received"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#c396e0"
+              }
+            ]
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "COLUMN",
+              "alias": "Sent"
+            },
+            "seriesOverrides": [
+              {
+                "name": "Select series",
+                "color": "#00a1b2"
+              }
+            ]
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E",
+                "F",
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F YotiCallback: Approx. Number of Messages Delayed and Not Visible",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3002,
+        "left": 684,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Not Visible"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "COLUMN",
+              "alias": "Delayed"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D",
+                "E",
+                "G",
+                "H"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names,(cloud.aws.sqs.approximateNumberOfMessagesDelayedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F YotiCallback: Approx. Age of Oldest Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3002,
+        "left": 1368,
+        "width": 684,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Age of Oldest Message"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "I",
+                "J"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "F2F YotiCallback:  Messages Received by DLQ",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3002,
+        "left": 2052,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "NumberOfMessagesReceived",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "B:aws.account.id.name",
+            "B:queuename.name",
+            "C:aws.account.id.name",
+            "C:queuename.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion:filter(and(or(prefix(queuename,f2f-cri-api-YotiCallbackQueueDeadLetterQueue-)),or(ne(\"aws.account.id\",\"440208678480\")))):splitBy(\"aws.account.id\",queuename):sum:names:sort(dimension(\"aws.account.id\",ascending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1026,
+        "left": 684,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Account IDs:\n\nBUILD: 155922983858\nSTAGING: 065251012682"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1634,
+        "left": 684,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Account IDs:\n\nBUILD: 353376315620\nSTAGING: 065251012682"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 3610,
+        "left": 684,
+        "width": 684,
+        "height": 76
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## Account IDs:\n\nBUILD: 073717171046\nSTAGING: 417062968737"
     }
   ]
 }


### PR DESCRIPTION
# Description:
- Edit KIWI dashboards
- Previously, filters were hardcoded to show Production data only and the dashboards were missing some data in the non-prod instance
- This PR uses filters so that the data from build to prod can be viewed with the same json file
- `prefix` has also been used (similar to wildcard) to track resources that have environment specific name/AWS' autogenerated strings
- Also addresses other comments from https://govukverify.atlassian.net/browse/IPS-760?focusedCommentId=181080 (fixing broken links and missing data)

## Ticket number:
[IPS-1212](https://govukverify.atlassian.net/browse/IPS-1212)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence: The dashboards already exist in terraform, this PR updates their contents, see [modules in dashboards.tf](https://github.com/govuk-one-login/observability-configuration/blob/e7c3179521c1547234b22eb58781f0d89614cdde/dashboards.tf#L243)
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/b238bdf5-42d5-421a-b556-328cccbd8c21">
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/9e3043a3-dcca-4ce1-92a0-f455292ad6bb">


[IPS-1212]: https://govukverify.atlassian.net/browse/IPS-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ