### PR TITLE
OJ-2840: Add graph for SOAP token latency

### DIFF
--- a/dashboards/orange/experian-kbv-lambda-metrics.json
+++ b/dashboards/orange/experian-kbv-lambda-metrics.json
@@ -7170,7 +7170,210 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.submit_answers_durationByAccountIdRegionService:filter(and(or(eq(service,di-ipv-cri-kbv-api-answer)),or(eq(\"aws.region\",eu-west-2)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.submit_answers_durationByAccountIdRegionService:filter(and(or(eq(service,di-ipv-cri-kbv-api-answer)),or(eq(\"aws.region\",eu-west-2)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.submit_answers_durationByAccountIdRegionService:filter(and(or(eq(service,di-ipv-cri-kbv-api-answer)),or(eq(\"aws.region\",eu-west-2)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.submit_answers_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)),or(eq(service,di-ipv-cri-kbv-api-answer)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.submit_answers_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)),or(eq(service,di-ipv-cri-kbv-api-answer)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.submit_answers_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)),or(eq(service,di-ipv-cri-kbv-api-answer)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Soap Token Latency",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 1520,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id",
+          "spaceAggregation": "AVG",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.region",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "eu-west-2",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id",
+          "spaceAggregation": "MAX",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.region",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "eu-west-2",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id",
+          "spaceAggregation": "MIN",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "aws.region",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "eu-west-2",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "Kilo",
+            "valueFormat": "none",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "Kilo",
+            "valueFormat": "none",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "Kilo",
+            "valueFormat": "none",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
Added the following to kbv lambda metrics:

<img width="295" alt="Screenshot 2024-11-20 at 10 48 47" src="https://github.com/user-attachments/assets/7235c254-d184-41eb-8b66-46b2da401cf5">

## Ticket number:
[OJ-2840]

[OJ-2840]: https://govukverify.atlassian.net/browse/OJ-2840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ