### PR TITLE
ATB-1862 | Add Token Validation Failed Metric to Authoriser Issues panel

### DIFF
--- a/dashboards/encrypted-vc-storage/encrypted_vc_storage_dashboard.json
+++ b/dashboards/encrypted-vc-storage/encrypted_vc_storage_dashboard.json
@@ -2199,6 +2199,19 @@
           "metricSelector": "cloud.aws.vcstorage.tokeN_VALIDATION_ERRORByAccountIdRegionservice:count",
           "rate": "NONE",
           "enabled": true
+        },
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "aws.region",
+            "service"
+          ],
+          "metricSelector": "cloud.aws.vcstorage.tokeN_VALIDATION_FAILEDBByAccountIdRegionservice:count",
+          "rate": "NONE",
+          "enabled": true
         }
       ],
       "visualConfig": {
@@ -2259,6 +2272,17 @@
               "alias": "JWT Validation Error"
             },
             "seriesOverrides": []
+          },
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN",
+              "alias": "JWT Failure"
+            },
+            "seriesOverrides": []
           }
         ],
         "axes": {
@@ -2278,7 +2302,8 @@
                 "B",
                 "C",
                 "D",
-                "E"
+                "E",
+                "F"
               ],
               "defaultAxis": true
             }
@@ -2314,7 +2339,8 @@
             "A:service.name",
             "B:service.name",
             "D:service.name",
-            "E:service.name"
+            "E:service.name",
+            "F:service.name"
           ]
         },
         "graphChartSettings": {
@@ -2330,7 +2356,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.vcstorage.issueR_UNRECOGNISEDByAccountIdRegionservice:splitBy(service):filter(contains(service,Auth)):count):limit(100):names,(cloud.aws.vcstorage.jwkS_KID_NOT_PRESENTByAccountIdRegionservice:count):limit(100):names,(cloud.aws.vcstorage.jwkS_TIMEOUTByAccountIdRegionservice:count):limit(100):names,(cloud.aws.vcstorage.jwkS_UNREACHABLEByAccountIdRegionservice:count):limit(100):names,(cloud.aws.vcstorage.tokeN_VALIDATION_ERRORByAccountIdRegionservice:count):limit(100):names"
+        "resolution=null&(cloud.aws.vcstorage.issueR_UNRECOGNISEDByAccountIdRegionservice:splitBy(service):filter(contains(service,Auth)):count):limit(100):names,(cloud.aws.vcstorage.jwkS_KID_NOT_PRESENTByAccountIdRegionservice:count):limit(100):names,(cloud.aws.vcstorage.jwkS_TIMEOUTByAccountIdRegionservice:count):limit(100):names,(cloud.aws.vcstorage.jwkS_UNREACHABLEByAccountIdRegionservice:count):limit(100):names,(cloud.aws.vcstorage.tokeN_VALIDATION_ERRORByAccountIdRegionservice:count):limit(100):names,(cloud.aws.vcstorage.tokeN_VALIDATION_FAILEDByAccountIdRegionservice:count):limit(100):names"
       ]
     },
     {


### PR DESCRIPTION
# Description:

## Ticket number:
[ATB-1862 | Add Token Validation Failed Metric to Authoriser Issues panel
](https://govukverify.atlassian.net/browse/ATB-1862)

Added the metric ` cloud.aws.vcstorage.tokeN_VALIDATION_FAILEDByAccountIdRegionservice:count` to Authorizer Issues tile. 

Tested in Dev by running the pipeline: 
<img width="717" alt="Screenshot 2024-12-06 at 11 03 51" src="https://github.com/user-attachments/assets/4d0e544b-9a82-408e-9136-29daf3ef9a0e">


## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
