### PR TITLE
Bau/tweak ticf dashboard

### DIFF
--- a/dashboards/authentication/di-auth-ticf/di-auth-ticf.json.tpl
+++ b/dashboards/authentication/di-auth-ticf/di-auth-ticf.json.tpl
@@ -264,6 +264,17 @@
               "seriesOverrides": []
             },
             {
+              "matcher": "C:",
+              "unitTransform": "auto",
+              "valueFormat": "auto",
+              "properties": {
+                "color": "DEFAULT",
+                "seriesType": "LINE",
+                "alias": "400"
+              },
+              "seriesOverrides": []
+            },
+            {
               "matcher": "D:",
               "unitTransform": "auto",
               "valueFormat": "auto",

--- a/dashboards/authentication/di-auth-ticf/di-auth-ticf.json.tpl
+++ b/dashboards/authentication/di-auth-ticf/di-auth-ticf.json.tpl
@@ -270,7 +270,7 @@
               "properties": {
                 "color": "DEFAULT",
                 "seriesType": "LINE",
-                "alias": "403"
+                "alias": "500"
               },
               "seriesOverrides": []
             },

--- a/dashboards/authentication/di-auth-ticf/di-auth-ticf.json.tpl
+++ b/dashboards/authentication/di-auth-ticf/di-auth-ticf.json.tpl
@@ -3,7 +3,7 @@
   },
   "dashboardMetadata": {
     "name": "Authentication - TICF CRI (${application_environment})",
-    "shared": false,
+    "shared": true,
     "owner": "becka.lelew@digital.cabinet-office.gov.uk",
     "hasConsistentColors": false,
     "tags": [


### PR DESCRIPTION
# Description:

Some tweaks to the auth TICF CRI dashboard:

* Sets shared to true in line with other dashboards
* Fixes an existing alias for a metric and adds a new alias


## Checklist:
- [x] Is my change backwards compatible? Please include evidence