### PR TITLE
AUT-3879: Remove non prod dashboards for auth notify

### DIFF
--- a/dashboards.tf
+++ b/dashboards.tf
@@ -199,18 +199,6 @@ module "di_auth_ticf_production_dashboard" {
   application_environment = "production"
 }
 
-module "di_auth_notify_staging_dashboard" {
-  count  = local.is_production ? 0 : 1
-  source = "./dashboards/authentication/di-auth-notify-delivery-receipts"
-
-  application_environment = "staging"
-}
-module "di_auth_notify_integration_dashboard" {
-  count  = local.is_production ? 0 : 1
-  source = "./dashboards/authentication/di-auth-notify-delivery-receipts"
-
-  application_environment = "integration"
-}
 module "di_auth_notify_production_dashboard" {
   count  = local.is_production ? 1 : 0
   source = "./dashboards/authentication/di-auth-notify-delivery-receipts"


### PR DESCRIPTION
We don't currently have the notify callback wired up in envs other than production so these dashboards are showing no data. Removing so it's not misleading. I'm not removing the parameterisation in the template / terraform for now in case we change this in future

Last PR on this hopefully!

## Ticket number:
AUT-3879
