### PR TITLE
Added service alerting configuration for the onboarding product page

### DIFF
--- a/services_anomaly_detection.tf
+++ b/services_anomaly_detection.tf
@@ -39,7 +39,6 @@ resource "dynatrace_service_anomalies_v2" "dva_anomaly_settings" {
   }
 }
 
-# Anomaly detection settings to be applied at a service level
 resource "dynatrace_service_anomalies_v2" "dvla_anomaly_settings" {
   scope = "SERVICE-63AD630610311EBF"
   failure_rate {
@@ -434,6 +433,46 @@ resource "dynatrace_service_anomalies_v2" "servicenow_anomaly_settings" {
       }
       response_time_slowest {
         slowest_degradation_milliseconds = 1000
+        slowest_degradation_percent      = 100
+      }
+    }
+  }
+}
+
+resource "dynatrace_service_anomalies_v2" "onboarding_product_page_anomaly_settings" {
+  scope = "SERVICE-9713F44B641C67F8"
+  failure_rate {
+    enabled        = true
+    detection_mode = "auto"
+    auto_detection {
+      absolute_increase = 40
+      relative_increase = 50
+      over_alerting_protection {
+        minutes_abnormal_state = 5
+        requests_per_minute    = 1
+      }
+    }
+  }
+  load_drops {
+    enabled = false
+  }
+  load_spikes {
+    enabled = false
+  }
+  response_time {
+    enabled        = true
+    detection_mode = "auto"
+    auto_detection {
+      over_alerting_protection {
+        minutes_abnormal_state = 30
+        requests_per_minute    = 10
+      }
+      response_time_all {
+        degradation_milliseconds = 4000
+        degradation_percent      = 50
+      }
+      response_time_slowest {
+        slowest_degradation_milliseconds = 60000
         slowest_degradation_percent      = 100
       }
     }


### PR DESCRIPTION
# Description:
Following consultation with the TSD and the Dev team, this service produces weekly alerts that are non-actionable and these changes are to amend the alerting thresholds specifically for this service and in particular, the response time degradation alerting.

## Ticket number:
PSREGOV-1700

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
