### PR TITLE
Fix per-minute graphs for sign-ups and sign-ins service-health-overvi…

### DIFF
--- a/dashboards/service-health-overview-tsd.json
+++ b/dashboards/service-health-overview-tsd.json
@@ -818,7 +818,7 @@
         "resolution": "1m"
       },
       "metricExpressions": [
-        "resolution=1m&(cloud.aws.authentication.signInExistingAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(cloud.aws.authentication.authenticationSuccessExistingAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=1m&(cloud.aws.authentication.signInExistingAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:rate(1m)):limit(100):names,(cloud.aws.authentication.authenticationSuccessExistingAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:rate(1m)):limit(100):names"
       ]
     },
     {
@@ -955,7 +955,7 @@
         "resolution": "1m"
       },
       "metricExpressions": [
-        "resolution=1m&(cloud.aws.authentication.signInNewAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(cloud.aws.authentication.authenticationSuccessNewAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=1m&(cloud.aws.authentication.signInNewAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:rate(1m)):limit(100):names,(cloud.aws.authentication.authenticationSuccessNewAccountByClientByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:splitBy():sum:rate(1m)):limit(100):names"
       ]
     },
     {


### PR DESCRIPTION
…ew-tsd.json

# Description:
There is an issue with the current metric expressions for these two graphs. When you zoom out the timeframe Dynatrace will force a time resolution of greater than 1 min. With the current metric expression this will aggregate the values instead of displaying them as a rate of per-minute.

This fixes the metric expression so that the graphs work correctly and resolve to a per-minute value regardless of the timeframe selected.

## Ticket number:
[PSREGOV-1938](https://govukverify.atlassian.net/browse/PSREGOV-1938)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
