### PR TITLE
OJ-2845: Remove dimensions from duration metrics

### DIFF
--- a/dashboards/orange/experian-kbv-cri.json
+++ b/dashboards/orange/experian-kbv-cri.json
@@ -2252,7 +2252,7 @@
       "queries": [
         {
           "id": "A",
-          "metric": "cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionexecution_durationoutcometransition_id",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionoutcome",
           "spaceAggregation": "SUM",
           "timeAggregation": "DEFAULT",
           "splitBy": [
@@ -2333,7 +2333,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionexecution_durationoutcometransition_id:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionoutcome:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -2587,7 +2587,7 @@
       "queries": [
         {
           "id": "A",
-          "metric": "cloud.aws.di-ipv-cri-kbv-api.initial_questions_responseByAccountIdRegionexecution_durationoutcometransition_id",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.initial_questions_responseByAccountIdRegionoutcome",
           "spaceAggregation": "SUM",
           "timeAggregation": "DEFAULT",
           "splitBy": [
@@ -2662,7 +2662,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.initial_questions_responseByAccountIdRegionexecution_durationoutcometransition_id:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.initial_questions_responseByAccountIdRegionoutcome:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -2681,7 +2681,7 @@
       "queries": [
         {
           "id": "A",
-          "metric": "cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionexecution_durationoutcometransition_id",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionoutcome",
           "spaceAggregation": "SUM",
           "timeAggregation": "DEFAULT",
           "splitBy": [
@@ -2752,7 +2752,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionexecution_durationoutcometransition_id:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+        "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionoutcome:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -2869,7 +2869,7 @@
       "queries": [
         {
           "id": "A",
-          "metric": "cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionexecution_durationoutcometransition_id",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionoutcome",
           "spaceAggregation": "SUM",
           "timeAggregation": "DEFAULT",
           "splitBy": [
@@ -2978,7 +2978,7 @@
         "foldAggregation": "AVG"
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionexecution_durationoutcometransition_id:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):names:fold(avg),(cloud.aws.di-ipv-cri-kbv-api.abandon_kbvByAccountIdRegionService:splitBy():sum:sort(value(sum,descending)):limit(20)):names:fold(avg)"
+        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.submit_questions_responseByAccountIdRegionoutcome:splitBy(outcome):sum:sort(value(sum,descending)):limit(20)):names:fold(avg),(cloud.aws.di-ipv-cri-kbv-api.abandon_kbvByAccountIdRegionService:splitBy():sum:sort(value(sum,descending)):limit(20)):names:fold(avg)"
       ]
     },
     {

--- a/dashboards/orange/experian-kbv-lambda-metrics.json
+++ b/dashboards/orange/experian-kbv-lambda-metrics.json
@@ -7189,7 +7189,7 @@
       "queries": [
         {
           "id": "A",
-          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionService",
           "spaceAggregation": "AVG",
           "timeAggregation": "DEFAULT",
           "splitBy": [],
@@ -7219,7 +7219,7 @@
         },
         {
           "id": "B",
-          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionService",
           "spaceAggregation": "MAX",
           "timeAggregation": "DEFAULT",
           "splitBy": [],
@@ -7249,7 +7249,7 @@
         },
         {
           "id": "C",
-          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionService",
           "spaceAggregation": "MIN",
           "timeAggregation": "DEFAULT",
           "splitBy": [],
@@ -7373,7 +7373,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionexecution_durationoutcometransition_id:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_soap_token_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Minor updates to Experian KBV dashboards as `execution_duration` and `transition_id` dimensions will no longer exist when the following is merged: https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/458 

## Screenshots
![image](https://github.com/user-attachments/assets/00cd64bc-4215-4825-9d9d-18ab44eb1d14)
![image](https://github.com/user-attachments/assets/2733e094-74cd-46df-9426-f168d1fd55e4)

## Ticket number:
- [OJ-2845](https://govukverify.atlassian.net/browse/OJ-2845)

[OJ-2845]: https://govukverify.atlassian.net/browse/OJ-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ