### PR TITLE
BAU: Remove the Auth inactive CloudFront Monitor dashboard

### DIFF
--- a/dashboards-cloudfront.tf
+++ b/dashboards-cloudfront.tf
@@ -25,12 +25,6 @@ variable "teamscloudfront1" {
       awsaccprod = "821078365651"
       awsaccint  = "988112579449"
     }
-    "team-e" = {
-      owneremail = "pawankumar.kushwaha@digital.cabinet-office.gov.uk"
-      teamname   = "Auth - gds-di-production"
-      awsaccprod = "172348255554"
-      awsaccint  = "761723964695"
-    }
     "team-f" = {
       owneremail = "cri-orange-team@digital.cabinet-office.gov.uk"
       teamname   = "Orange - NINo-CRI"


### PR DESCRIPTION
# Description:
Remove the Auth inactive CloudFront Monitor dashboard , This dashboard was created for CloudFront Migration not is use so can be removed 

## Ticket number:
[N/A]

## Checklist:
- [ yes] Is my change backwards compatible? Please include evidence
- [no ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
