### PR TITLE
SPT-1256: Added key-rotations-dashboard to TF

### DIFF
--- a/dashboards.tf
+++ b/dashboards.tf
@@ -232,11 +232,14 @@ module "spot_lambda_metrics_dashboard" {
   source = "./modules/dashboard"
   path   = "spot/lambda-metrics.json"
 }
+module "spot_key_rotations_dashboard" {
+  source = "./modules/dashboard"
+  path   = "spot/key-rotation-dashboard.json"
+}
 module "spot_cimit_apigateway_metrics_dashboard" {
   source = "./modules/dashboard"
   path   = "spot/cimit-api-gateway.json"
 }
-
 
 ### Kiwi ###
 


### PR DESCRIPTION
# Description:

Added `key-rotations-dashboard.json` to dashboards Terraform configuration as module `spot_key_rotations_dashboard`. So that the SPOT Key Rotations Dashboard is deployed.

## Ticket number:
[SPT-1256](https://govukverify.atlassian.net/browse/SPT-1256)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence - Adds additional dashboard.
- [x] I have tested this and added output to Jira Comment: Image of dashboard present in ticket.
- [x] Documentation added (link) Comment: N/A. Adds existing dashboard to _dashboards.tf_.


[SPT-1256]: https://govukverify.atlassian.net/browse/SPT-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ