### PR TITLE
Added in config to customise user session percentage

### DIFF
--- a/modules/web_application/main.tf
+++ b/modules/web_application/main.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_web_application" "web_application" {
   name                                 = var.name
   type                                 = "AUTO_INJECTED"
-  cost_control_user_session_percentage = 100
+  cost_control_user_session_percentage = var.user_session_percentage
   load_action_key_performance_metric   = "VISUALLY_COMPLETE"
   real_user_monitoring_enabled         = var.enabled
   xhr_action_key_performance_metric    = "ACTION_DURATION"

--- a/modules/web_application/variables.tf
+++ b/modules/web_application/variables.tf
@@ -17,3 +17,7 @@ variable "opt_in_enabled" {
 variable "manual_injection" {
   type = bool
 }
+
+variable "user_session_percentage" {
+  type = number
+}

--- a/web_applications.tf
+++ b/web_applications.tf
@@ -1,69 +1,82 @@
 locals {
   one_login_subdomains = {
     signin = {
-      hostname         = "signin"
-      name             = "Authentication"
-      manual_injection = false
+      hostname                = "signin"
+      name                    = "Authentication"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     home = {
-      hostname         = "home"
-      name             = "Home"
-      manual_injection = true
+      hostname                = "home"
+      name                    = "Home"
+      manual_injection        = true
+      user_session_percentage = 50
     },
     identity = {
-      hostname         = "identity",
-      name             = "IPV Core"
-      manual_injection = true
+      hostname                = "identity"
+      name                    = "IPV Core"
+      manual_injection        = true
+      user_session_percentage = 50
     },
     review-a = {
-      hostname         = "review-a"
-      name             = "Address CRI"
-      manual_injection = false
+      hostname                = "review-a"
+      name                    = "Address CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-b = {
-      hostname         = "review-b"
-      name             = "Document App CRI"
-      manual_injection = false
+      hostname                = "review-b"
+      name                    = "Document App CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-bav = {
-      hostname         = "review-bav"
-      name             = "Bank Account Verification CRI"
-      manual_injection = false
+      hostname                = "review-bav"
+      name                    = "Bank Account Verification CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-c = {
-      hostname         = "review-c"
-      name             = "Claimed Identity Collector CRI"
-      manual_injection = false
+      hostname                = "review-c"
+      name                    = "Claimed Identity Collector CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-d = {
-      hostname         = "review-d"
-      name             = "Driving License CRI"
-      manual_injection = false
+      hostname                = "review-d"
+      name                    = "Driving License CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-f = {
-      hostname         = "review-f"
-      name             = "Fraud CRI"
-      manual_injection = false
+      hostname                = "review-f"
+      name                    = "Fraud CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-hc = {
-      hostname         = "review-hc"
-      name             = "HMRC NINO Check CRI"
-      manual_injection = false
+      hostname                = "review-hc"
+      name                    = "HMRC NINO Check CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-k = {
-      hostname         = "review-k"
-      name             = "Experian KBV CRI"
-      manual_injection = false
+      hostname                = "review-k"
+      name                    = "Experian KBV CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-o = {
-      hostname         = "review-o"
-      name             = "Face to Face CRI"
-      manual_injection = false
+      hostname                = "review-o"
+      name                    = "Face to Face CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     },
     review-pa = {
-      hostname         = "review-pa"
-      name             = "Passport CRI"
-      manual_injection = false
+      hostname                = "review-pa"
+      name                    = "Passport CRI"
+      manual_injection        = false
+      user_session_percentage = 50
     }
   }
 }
@@ -72,64 +85,70 @@ module "web_application_staging" {
   count  = var.environment == "nonproduction" ? 1 : 0
   source = "./modules/web_application"
 
-  hostname         = "staging.account.gov.uk"
-  name             = "Staging"
-  enabled          = true
-  opt_in_enabled   = true
-  manual_injection = false
+  hostname                = "staging.account.gov.uk"
+  name                    = "Staging"
+  enabled                 = true
+  opt_in_enabled          = true
+  manual_injection        = false
+  user_session_percentage = 50
 }
 
 module "web_application_staging_subdomains" {
   for_each = var.environment == "nonproduction" ? local.one_login_subdomains : {}
   source   = "./modules/web_application"
 
-  hostname         = "${each.value["hostname"]}.staging.account.gov.uk"
-  name             = "${each.value["name"]} Staging"
-  enabled          = true
-  opt_in_enabled   = true
-  manual_injection = each.value["manual_injection"]
+  hostname                = "${each.value["hostname"]}.staging.account.gov.uk"
+  name                    = "${each.value["name"]} Staging"
+  enabled                 = true
+  opt_in_enabled          = true
+  manual_injection        = each.value["manual_injection"]
+  user_session_percentage = each.value["user_session_percentage"]
 }
 
 module "web_application_integration" {
   count  = var.environment == "nonproduction" ? 1 : 0
   source = "./modules/web_application"
 
-  hostname         = "integration.account.gov.uk"
-  name             = "Integration"
-  enabled          = true
-  opt_in_enabled   = true
-  manual_injection = false
+  hostname                = "integration.account.gov.uk"
+  name                    = "Integration"
+  enabled                 = true
+  opt_in_enabled          = true
+  manual_injection        = false
+  user_session_percentage = 50
 }
 
 module "web_application_integration_subdomains" {
   for_each = var.environment == "nonproduction" ? local.one_login_subdomains : {}
   source   = "./modules/web_application"
 
-  hostname         = "${each.value["hostname"]}.integration.account.gov.uk"
-  name             = "${each.value["name"]} Integration"
-  enabled          = true
-  opt_in_enabled   = true
-  manual_injection = each.value["manual_injection"]
+  hostname                = "${each.value["hostname"]}.integration.account.gov.uk"
+  name                    = "${each.value["name"]} Integration"
+  enabled                 = true
+  opt_in_enabled          = true
+  manual_injection        = each.value["manual_injection"]
+  user_session_percentage = each.value["user_session_percentage"]
 }
 
 module "web_application_production" {
   count  = var.environment == "production" ? 1 : 0
   source = "./modules/web_application"
 
-  hostname         = "account.gov.uk"
-  name             = "Production"
-  enabled          = true
-  opt_in_enabled   = true
-  manual_injection = false
+  hostname                = "account.gov.uk"
+  name                    = "Production"
+  enabled                 = true
+  opt_in_enabled          = true
+  manual_injection        = false
+  user_session_percentage = 50
 }
 
 module "web_application_production_subdomains" {
   for_each = var.environment == "production" ? local.one_login_subdomains : {}
   source   = "./modules/web_application"
 
-  hostname         = "${each.value["hostname"]}.account.gov.uk"
-  name             = "${each.value["name"]} Production"
-  enabled          = true
-  opt_in_enabled   = true
-  manual_injection = each.value["manual_injection"]
+  hostname                = "${each.value["hostname"]}.account.gov.uk"
+  name                    = "${each.value["name"]} Production"
+  enabled                 = true
+  opt_in_enabled          = true
+  manual_injection        = each.value["manual_injection"]
+  user_session_percentage = each.value["user_session_percentage"]
 }


### PR DESCRIPTION
# Description:
Due to increased Dynatrace costs and RUM being the second most expensive feature, this work is to implement customisation for the cost_control_user_session_percentage attribute and this has currently been set from the original 100% to 50% across the board.
If needed in the future, this config allows the value to be amended per RUM application.

## Ticket number:
PSREGOV-2099

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
