### PR TITLE
RUM updated for custom injection rules

### DIFF
--- a/modules/web_application/injection_rules.tf
+++ b/modules/web_application/injection_rules.tf
@@ -1,7 +1,0 @@
-resource "dynatrace_web_app_custom_injection" "web_application" {
-  count          = var.manual_injection == true ? 1 : 0
-  enabled        = true
-  application_id = dynatrace_web_application.web_application.id
-  operator       = "AllPages"
-  rule           = "DoNotInject"
-}

--- a/modules/web_application/main.tf
+++ b/modules/web_application/main.tf
@@ -58,6 +58,12 @@ resource "dynatrace_web_application" "web_application" {
     }
     javascript_framework_support {
     }
+    javascript_injection_rules {
+      rule {
+        rule         = var.injection_rule 
+        url_operator = var.injection_operator
+      }
+    }
   }
   session_replay_config {
     enabled                       = false

--- a/modules/web_application/variables.tf
+++ b/modules/web_application/variables.tf
@@ -1,23 +1,32 @@
 variable "hostname" {
+  description = "This value is used as part of the domain name for each RUM application"
 }
 
 variable "name" {
+  description = "This is the name of the RUM application as seen within the Dynatrace UI"
 }
 
 variable "enabled" {
-  type    = bool
-  default = true
+  description = "This determines whether RUM is enabled or not for the respective application"
+  type        = bool
+  default     = true
 }
 
 variable "opt_in_enabled" {
-  type    = bool
-  default = true
-}
-
-variable "manual_injection" {
-  type = bool
+  description = "This is used as part of the data privacy for RUM and cookie consent setup"
+  type        = bool
+  default     = true
 }
 
 variable "user_session_percentage" {
-  type = number
+  description = "This variable controls the number of sessions captured within each RUM application"
+  type        = number
+}
+
+variable "injection_rule" {
+  description = "The rule for determining how the RUM javascript should be injected"
+}
+
+variable "injection_operator" {
+  description = "The URL operator for determining where the RUM javascript should be injected"
 }

--- a/web_applications.tf
+++ b/web_applications.tf
@@ -3,80 +3,93 @@ locals {
     signin = {
       hostname                = "signin"
       name                    = "Authentication"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     home = {
       hostname                = "home"
       name                    = "Home"
-      manual_injection        = true
       user_session_percentage = 50
+      injection_rule          = "DO_NOT_INJECT"
+      injection_operator      = "ALL_PAGES"
     },
     identity = {
       hostname                = "identity"
       name                    = "IPV Core"
-      manual_injection        = true
       user_session_percentage = 50
+      injection_rule          = "DO_NOT_INJECT"
+      injection_operator      = "ALL_PAGES"
     },
     review-a = {
       hostname                = "review-a"
       name                    = "Address CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-b = {
       hostname                = "review-b"
       name                    = "Document App CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-bav = {
       hostname                = "review-bav"
       name                    = "Bank Account Verification CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-c = {
       hostname                = "review-c"
       name                    = "Claimed Identity Collector CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-d = {
       hostname                = "review-d"
       name                    = "Driving License CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-f = {
       hostname                = "review-f"
       name                    = "Fraud CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-hc = {
       hostname                = "review-hc"
       name                    = "HMRC NINO Check CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-k = {
       hostname                = "review-k"
       name                    = "Experian KBV CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-o = {
       hostname                = "review-o"
       name                    = "Face to Face CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     },
     review-pa = {
       hostname                = "review-pa"
       name                    = "Passport CRI"
-      manual_injection        = false
       user_session_percentage = 50
+      injection_rule          = "AUTOMATIC_INJECTION"
+      injection_operator      = "ALL_PAGES"
     }
   }
 }
@@ -89,8 +102,9 @@ module "web_application_staging" {
   name                    = "Staging"
   enabled                 = true
   opt_in_enabled          = true
-  manual_injection        = false
   user_session_percentage = 50
+  injection_rule          = "AUTOMATIC_INJECTION"
+  injection_operator      = "ALL_PAGES"
 }
 
 module "web_application_staging_subdomains" {
@@ -101,8 +115,9 @@ module "web_application_staging_subdomains" {
   name                    = "${each.value["name"]} Staging"
   enabled                 = true
   opt_in_enabled          = true
-  manual_injection        = each.value["manual_injection"]
   user_session_percentage = each.value["user_session_percentage"]
+  injection_rule          = each.value["injection_rule"]
+  injection_operator      = each.value["injection_operator"]
 }
 
 module "web_application_integration" {
@@ -113,8 +128,9 @@ module "web_application_integration" {
   name                    = "Integration"
   enabled                 = true
   opt_in_enabled          = true
-  manual_injection        = false
   user_session_percentage = 50
+  injection_rule          = "AUTOMATIC_INJECTION"
+  injection_operator      = "ALL_PAGES"
 }
 
 module "web_application_integration_subdomains" {
@@ -125,8 +141,9 @@ module "web_application_integration_subdomains" {
   name                    = "${each.value["name"]} Integration"
   enabled                 = true
   opt_in_enabled          = true
-  manual_injection        = each.value["manual_injection"]
   user_session_percentage = each.value["user_session_percentage"]
+  injection_rule          = each.value["injection_rule"]
+  injection_operator      = each.value["injection_operator"]
 }
 
 module "web_application_production" {
@@ -137,8 +154,9 @@ module "web_application_production" {
   name                    = "Production"
   enabled                 = true
   opt_in_enabled          = true
-  manual_injection        = false
   user_session_percentage = 50
+  injection_rule          = "AUTOMATIC_INJECTION"
+  injection_operator      = "ALL_PAGES"
 }
 
 module "web_application_production_subdomains" {
@@ -149,6 +167,7 @@ module "web_application_production_subdomains" {
   name                    = "${each.value["name"]} Production"
   enabled                 = true
   opt_in_enabled          = true
-  manual_injection        = each.value["manual_injection"]
   user_session_percentage = each.value["user_session_percentage"]
+  injection_rule          = each.value["injection_rule"]
+  injection_operator      = each.value["injection_operator"]
 }


### PR DESCRIPTION
# Description:
Removal of the old RUM custom injection rules config as it was conflicting with the `dynatrace_web_application` javascript injection rules attribute that was missing, on the premise that the aforementioned resource should have worked.
This new config defines an injection rule against each RUM application, two are set to not automatically inject while the rest are set to automatic injection.

## Ticket number:
PSREGOV-1233

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
