### PR TITLE
Exclude Dependabot PRs from workflow execution

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,9 @@ name: Check Terraform Configuration
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
+    branches-ignore:
+      - 'dependabot/**'
 
 env:
   DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}


### PR DESCRIPTION
# Description:
Prevent workflow runs on Dependabot pull requests by adding `branches-ignore` filter. This avoids potential failures due to missing secret access for automated dependency updates.

## Ticket number:
[PSREGOV-2132](https://govukverify.atlassian.net/browse/PSREGOV-2312)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[PSREGOV-2132]: https://govukverify.atlassian.net/browse/PSREGOV-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ