### PR TITLE
PSREGOV 2080 - Update Dynatrace dashboard to reflect policy processing pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ accounts.csv
 .idea/
 
 build/
+
+.DS_Store

--- a/dashboards/team-idc-app.json
+++ b/dashboards/team-idc-app.json
@@ -1,13 +1,15 @@
 {
   "metadata": {
-    "configurationVersions": [7],
-    "clusterVersion": "1.311.47.20250401-131413"
+    "configurationVersions": [
+      7
+    ],
+    "clusterVersion": "1.311.51.20250403-172833"
   },
   "dashboardMetadata": {
     "name": "team-idc-app",
     "shared": true,
     "owner": "stevan.beattie@digital.cabinet-office.gov.uk",
-    "popularity": 1,
+    "popularity": 6,
     "hasConsistentColors": false
   },
   "tiles": [
@@ -30,7 +32,9 @@
           "metric": "builtin:cloud.aws.lambda.invocations",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["dt.entity.aws_lambda_function"],
+          "splitBy": [
+            "dt.entity.aws_lambda_function"
+          ],
           "sortBy": "DESC",
           "sortByDimension": "",
           "filterBy": {
@@ -82,7 +86,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -177,7 +183,9 @@
           "metric": "builtin:cloud.aws.lambda.throttlers",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["dt.entity.aws_lambda_function"],
+          "splitBy": [
+            "dt.entity.aws_lambda_function"
+          ],
           "sortBy": "DESC",
           "sortByDimension": "",
           "filterBy": {
@@ -321,7 +329,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -400,7 +410,9 @@
           "metric": "builtin:cloud.aws.lambda.duration",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["dt.entity.aws_lambda_function"],
+          "splitBy": [
+            "dt.entity.aws_lambda_function"
+          ],
           "filterBy": {
             "filterOperator": "AND",
             "nestedFilters": [
@@ -449,7 +461,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -516,7 +530,9 @@
           "metric": "builtin:cloud.aws.lambda.duration",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["dt.entity.aws_lambda_function"],
+          "splitBy": [
+            "dt.entity.aws_lambda_function"
+          ],
           "sortBy": "DESC",
           "sortByDimension": "",
           "filterBy": {
@@ -622,7 +638,9 @@
           "metric": "builtin:cloud.aws.lambda.errorsRate",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["dt.entity.aws_lambda_function"],
+          "splitBy": [
+            "dt.entity.aws_lambda_function"
+          ],
           "sortBy": "DESC",
           "sortByDimension": "",
           "filterBy": {
@@ -672,7 +690,9 @@
               "min": "0",
               "max": "100",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -758,7 +778,9 @@
           "metric": "builtin:cloud.aws.lambda.throttlers",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["dt.entity.aws_lambda_function"],
+          "splitBy": [
+            "dt.entity.aws_lambda_function"
+          ],
           "filterBy": {
             "filterOperator": "AND",
             "nestedFilters": [
@@ -807,7 +829,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -946,7 +970,10 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["C", "D"],
+              "queryIds": [
+                "C",
+                "D"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1068,7 +1095,10 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["C", "D"],
+              "queryIds": [
+                "C",
+                "D"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1167,7 +1197,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["B"],
+              "queryIds": [
+                "B"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1266,7 +1298,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["B"],
+              "queryIds": [
+                "B"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1438,7 +1472,11 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["F", "G", "H"],
+              "queryIds": [
+                "F",
+                "G",
+                "H"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1612,7 +1650,12 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["E", "F", "H", "G"],
+              "queryIds": [
+                "E",
+                "F",
+                "H",
+                "G"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1674,7 +1717,9 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["statemachinearn"],
+          "splitBy": [
+            "statemachinearn"
+          ],
           "metricSelector": "cloud.aws.states.executionTimeByAccountIdRegionStateMachineArn:sort(value(auto,descending)):limit(20):filter(and(or(eq(\"aws.account.id\",\"708169909512\")))):splitBy(statemachinearn)",
           "rate": "NONE",
           "enabled": true
@@ -1704,7 +1749,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1766,7 +1813,9 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["statemachinearn"],
+          "splitBy": [
+            "statemachinearn"
+          ],
           "metricSelector": "cloud.aws.states.executionsSucceededByAccountIdRegionStateMachineArn:sum:sort(value(sum,descending)):limit(20):filter(and(or(eq(\"aws.account.id\",\"708169909512\")))):splitBy(statemachinearn)",
           "rate": "NONE",
           "enabled": true
@@ -1796,7 +1845,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1858,7 +1909,9 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["statemachinearn"],
+          "splitBy": [
+            "statemachinearn"
+          ],
           "metricSelector": "cloud.aws.states.executionsAbortedByAccountIdRegionStateMachineArn:filter(and(or(eq(\"aws.account.id\",\"708169909512\")))):splitBy(statemachinearn):sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -1867,7 +1920,9 @@
           "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["statemachinearn"],
+          "splitBy": [
+            "statemachinearn"
+          ],
           "metricSelector": "cloud.aws.states.executionsFailedByAccountIdRegionStateMachineArn:filter(and(or(eq(\"aws.account.id\",\"708169909512\")))):splitBy(statemachinearn):sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -1904,7 +1959,10 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A", "B"],
+              "queryIds": [
+                "A",
+                "B"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1972,7 +2030,9 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["statemachinearn"],
+          "splitBy": [
+            "statemachinearn"
+          ],
           "metricSelector": "cloud.aws.states.executionThrottledByAccountIdRegionStateMachineArn:sum:sort(value(sum,descending)):limit(20):filter(and(or(eq(\"aws.account.id\",\"708169909512\")))):splitBy(statemachinearn)",
           "rate": "NONE",
           "enabled": true
@@ -2002,7 +2062,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -2066,7 +2128,9 @@
           "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["tablename"],
+          "splitBy": [
+            "tablename"
+          ],
           "metricSelector": "cloud.aws.dynamodb.consumedReadCapacityUnitsByAccountIdRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", \"708169909512\"))):splitBy(tablename):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2151,7 +2215,9 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["tablename"],
+          "splitBy": [
+            "tablename"
+          ],
           "metricSelector": "cloud.aws.dynamodb.consumedWriteCapacityUnitsByAccountIdRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", \"708169909512\"))):splitBy(tablename):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2236,7 +2302,9 @@
           "id": "B",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["tablename"],
+          "splitBy": [
+            "tablename"
+          ],
           "metricSelector": "cloud.aws.dynamodb.successfulRequestLatencyByAccountIdOperationRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", \"708169909512\"))):splitBy(tablename):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2266,7 +2334,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["B"],
+              "queryIds": [
+                "B"
+              ],
               "defaultAxis": true
             }
           ]
@@ -2340,7 +2410,9 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["aws.region"],
+          "splitBy": [
+            "aws.region"
+          ],
           "metricSelector": "cloud.aws.dynamodb.userErrorsByAccountIdRegion:filter(and(or(eq(\"aws.account.id\", \"708169909512\")))):splitBy(aws.region):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2371,7 +2443,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -2439,7 +2513,9 @@
           "id": "D",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["tablename"],
+          "splitBy": [
+            "tablename"
+          ],
           "metricSelector": "cloud.aws.dynamodb.consumedReadCapacityUnitsByAccountIdRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", \"708169909512\"))):splitBy(tablename):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2448,7 +2524,9 @@
           "id": "E",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["tablename"],
+          "splitBy": [
+            "tablename"
+          ],
           "metricSelector": "cloud.aws.dynamodb.consumedWriteCapacityUnitsByAccountIdRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", \"708169909512\"))):splitBy(tablename):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2485,7 +2563,10 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["D", "E"],
+              "queryIds": [
+                "D",
+                "E"
+              ],
               "defaultAxis": true
             }
           ]
@@ -2557,7 +2638,9 @@
           "id": "C",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["tablename"],
+          "splitBy": [
+            "tablename"
+          ],
           "metricSelector": "cloud.aws.dynamodb.readThrottleEventsByAccountIdRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", \"708169909512\"))):splitBy(\"tablename\"):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2665,7 +2748,9 @@
           "id": "C",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["tablename"],
+          "splitBy": [
+            "tablename"
+          ],
           "metricSelector": "cloud.aws.dynamodb.successfulRequestLatencyByAccountIdOperationRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", \"708169909512\"))):splitBy(\"tablename\"):sort(value(auto,descending)):limit(20)",
           "rate": "NONE",
           "enabled": true
@@ -2793,7 +2878,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -2890,7 +2977,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -2932,6 +3021,1307 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.amplifyhosting.latencyByAccountIdRegion:filter(and(or(eq(\"aws.account.id\",\"708169909512\")))):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Policy Processing Resources",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 2470,
+        "left": 0,
+        "width": 1216,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "Lambda Error Rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 342,
+        "left": 608,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "DLQ",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 3230,
+        "left": 0,
+        "width": 304,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "Lambda",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 2508,
+        "left": 0,
+        "width": 304,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "DynamoDB",
+      "tileType": "HEADER",
+      "configured": true,
+      "bounds": {
+        "top": 3610,
+        "left": 0,
+        "width": 304,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false
+    },
+    {
+      "name": "DLQ Messages",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3268,
+        "left": 456,
+        "width": 760,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "aws.region",
+            "dt.entity.cloud:aws:account",
+            "dt.entity.cloud:aws:region",
+            "dt.entity.cloud:aws:sqs:queue",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion:filter(and(eq(\"aws.account.id\",\"708169909512\"),eq(\"queuename\",\"TEAMPolicyPublishingFunctionDLQ\")))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "0",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion:filter(and(eq(\"aws.account.id\",\"708169909512\"),eq(queuename,TEAMPolicyPublishingFunctionDLQ)))):limit(100):names"
+      ]
+    },
+    {
+      "name": "Consumed Write Capacity Units",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3648,
+        "left": 0,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.consumedWriteCapacityUnitsByAccountIdRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Approvers\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "G",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.consumedWriteCapacityUnitsByAccountIdRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Eligibility\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "PURPLE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "G:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "C",
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.dynamodb.consumedWriteCapacityUnitsByAccountIdRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Approvers))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.dynamodb.consumedWriteCapacityUnitsByAccountIdRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Eligibility))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Successful Request Latency",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3648,
+        "left": 608,
+        "width": 608,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.successfulRequestLatencyByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Approvers\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "H",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.successfulRequestLatencyByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Eligibility\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "H:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "PURPLE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "RIGHT",
+              "queryIds": [
+                "H",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.dynamodb.successfulRequestLatencyByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Approvers))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.dynamodb.successfulRequestLatencyByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Eligibility))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "System (500) Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4028,
+        "left": 0,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Approvers\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "H",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Eligibility\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "H:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "PURPLE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "H",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Approvers))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Eligibility))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "User (400) Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4028,
+        "left": 342,
+        "width": 342,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Approvers\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "H",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Eligibility\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "H:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "PURPLE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "H",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Approvers))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.dynamodb.systemErrorsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Eligibility))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Throttled Requests",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4028,
+        "left": 684,
+        "width": 532,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.throttledRequestsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Approvers\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "H",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "tablename"
+          ],
+          "metricSelector": "cloud.aws.dynamodb.throttledRequestsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(\"tablename\",\"Eligibility\"))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "H:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "PURPLE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "RIGHT",
+              "queryIds": [
+                "H",
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.dynamodb.throttledRequestsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Approvers))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names,(cloud.aws.dynamodb.throttledRequestsByAccountIdOperationRegionTableName:filter(and(eq(\"aws.account.id\",\"708169909512\"),prefix(tablename,Eligibility))):splitBy(\"aws.account.id\",tablename):sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Approximate Age of Oldest DLQ Message",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3268,
+        "left": 0,
+        "width": 456,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Approximate Age of Oldest DLQ Message",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "aws.region",
+            "dt.entity.cloud:aws:account",
+            "dt.entity.cloud:aws:region",
+            "dt.entity.cloud:aws:sqs:queue",
+            "queuename"
+          ],
+          "metricSelector": "cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(eq(\"aws.account.id\",\"708169909512\"),eq(\"queuename\",\"TEAMPolicyPublishingFunctionDLQ\")))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(eq(\"aws.account.id\",\"708169909512\"),eq(queuename,TEAMPolicyPublishingFunctionDLQ)))):limit(100):names",
+        "resolution=null&(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion:filter(and(eq(\"aws.account.id\",\"708169909512\"),eq(queuename,TEAMPolicyPublishingFunctionDLQ))))"
+      ]
+    },
+    {
+      "name": "Throttles",
+      "nameSize": "medium",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 608,
+        "width": 608,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "F",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "aws.region",
+            "dt.entity.cloud:aws:account",
+            "dt.entity.cloud:aws:lambda:function",
+            "dt.entity.cloud:aws:region",
+            "functionname"
+          ],
+          "metricSelector": "cloud.aws.lambda.throttlesByAccountIdFunctionNameRegion:filter(prefix(\"functionname\",\"TEAMPolicyLambda-PolicyPublishingFunction\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "F:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ORANGE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "F"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.lambda.throttlesByAccountIdFunctionNameRegion:filter(prefix(functionname,TEAMPolicyLambda-PolicyPublishingFunction))):limit(100):names"
+      ]
+    },
+    {
+      "name": "Errors",
+      "nameSize": "medium",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 0,
+        "width": 608,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "G",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "aws.region",
+            "dt.entity.cloud:aws:account",
+            "dt.entity.cloud:aws:lambda:function",
+            "dt.entity.cloud:aws:region",
+            "functionname"
+          ],
+          "metricSelector": "cloud.aws.lambda.errorsByAccountIdFunctionNameRegion:filter(prefix(\"functionname\",\"TEAMPolicyLambda-PolicyPublishingFunction\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "G:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ORANGE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.lambda.errorsByAccountIdFunctionNameRegion:filter(prefix(functionname,TEAMPolicyLambda-PolicyPublishingFunction))):limit(100):names"
+      ]
+    },
+    {
+      "name": "Execution Duration",
+      "nameSize": "medium",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2546,
+        "left": 608,
+        "width": 608,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "I",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "aws.region",
+            "dt.entity.cloud:aws:account",
+            "dt.entity.cloud:aws:lambda:function",
+            "dt.entity.cloud:aws:region",
+            "functionname"
+          ],
+          "metricSelector": "cloud.aws.lambda.durationByAccountIdFunctionNameRegion:filter(prefix(\"functionname\",\"TEAMPolicyLambda-PolicyPublishingFunction\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "I:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ORANGE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "I"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.lambda.durationByAccountIdFunctionNameRegion:filter(prefix(functionname,TEAMPolicyLambda-PolicyPublishingFunction))):limit(100):names"
+      ]
+    },
+    {
+      "name": "Concurrent Invocations",
+      "nameSize": "medium",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2546,
+        "left": 0,
+        "width": 608,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "G",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id",
+            "aws.region",
+            "dt.entity.cloud:aws:account",
+            "dt.entity.cloud:aws:lambda:function",
+            "dt.entity.cloud:aws:region",
+            "functionname"
+          ],
+          "metricSelector": "cloud.aws.lambda.concurrentExecutionsByAccountIdFunctionNameRegion:filter(prefix(\"functionname\",\"TEAMPolicyLambda-PolicyPublishingFunction\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "G:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "ORANGE",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "G"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.lambda.concurrentExecutionsByAccountIdFunctionNameRegion:filter(prefix(functionname,TEAMPolicyLambda-PolicyPublishingFunction))):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
- **Updated with tiles for TEAM Policy processing resources.**
- **Added .DS_Store to gitignore.**

@rorysedgwick confirmed he's happy with the new dashboard tiles so this will update the IaC config.

## Ticket number:
[PSREGOV-2080](https://govukverify.atlassian.net/browse/PSREGOV-2080)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[PSREGOV-2080]: https://govukverify.atlassian.net/browse/PSREGOV-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ