### PR TITLE
Ignore Dependabot branches for push events

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,11 @@
 name: Check Terraform Configuration
 
 on:
-  push:
+  push: 
+    branches:
+      - main
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     types: [opened, reopened, synchronize]
     branches-ignore:


### PR DESCRIPTION
# Description:
Ignore Dependabot branch pushes to prevent redundant workflow runs, complementing existing PR exclusion.
## Ticket number:
[PSREGOV-2312](https://govukverify.atlassian.net/browse/PSREGOV-2312)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
