### PR TITLE
fix: Prevent Dependabot workflow runs on push and PR events.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,6 @@ name: Check Terraform Configuration
 
 on:
   push: 
-    branches:
-      - main
     branches-ignore:
       - 'dependabot/**'
   pull_request:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,8 @@ name: Check Terraform Configuration
 
 on:
   push: 
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
     branches-ignore:


### PR DESCRIPTION
# Description:
Fix: Removed `main` from `push` to allow Dependabot branch exclusion. 

## Ticket number:
[[PSREGOV-2312]](https://govukverify.atlassian.net/browse/PSREGOV-2312)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[PSREGOV-2312]: https://govukverify.atlassian.net/browse/PSREGOV-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ