### PR TITLE
Skip checks on Dependabot PRs using conditional job execution.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,17 @@ env:
   DYNATRACE_HTTP_RESPONSE: "true"
 
 jobs:
+  Check_Branch:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ startsWith(github.head_ref, 'dependabot/') }}
+    steps:
+      - name: Check Branch
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          echo "Checking branch: $BRANCH_NAME"
+
   Check_DashboardFormat:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -80,6 +91,8 @@ jobs:
     env:
       DYNATRACE_API_TOKEN: ${{ secrets.NONPROD_DYNATRACE_API_TOKEN }}
       DYNATRACE_ENV_URL: ${{ secrets.NONPROD_DYNATRACE_ENV_URL }}
+    needs: Check_Branch
+    if: needs.check_branch.outputs.should_skip == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -132,6 +145,8 @@ jobs:
     env:
       DYNATRACE_API_TOKEN: ${{ secrets.PROD_DYNATRACE_API_TOKEN}}
       DYNATRACE_ENV_URL: ${{ secrets.PROD_DYNATRACE_ENV_URL}}
+    needs: Check_Branch
+    if: needs.check_branch.outputs.should_skip == 'false'      
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
       DYNATRACE_API_TOKEN: ${{ secrets.NONPROD_DYNATRACE_API_TOKEN }}
       DYNATRACE_ENV_URL: ${{ secrets.NONPROD_DYNATRACE_ENV_URL }}
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.actor != 'dependabot[bot]'
     timeout-minutes: 60
     permissions:
       id-token: write
@@ -77,6 +78,7 @@ jobs:
       DYNATRACE_API_TOKEN: ${{ secrets.PROD_DYNATRACE_API_TOKEN }}
       DYNATRACE_ENV_URL: ${{ secrets.PROD_DYNATRACE_ENV_URL }}
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.actor != 'dependabot[bot]'
     timeout-minutes: 60
     permissions:
       id-token: write


### PR DESCRIPTION
# Description:
Skip checks on Dependabot PRs to avoid secret access failures during automated dependency updates.
Fix: Prevent workflow execution on Dependabot PRs and subsequent deployment triggers from Dependabot merges.

## Ticket number:
[[PSREGOV-2312]](https://govukverify.atlassian.net/browse/PSREGOV-2312)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[PSREGOV-2312]: https://govukverify.atlassian.net/browse/PSREGOV-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ