### PR TITLE
Changed step function alert to auto adaptive threshold from static threshold

### DIFF
--- a/settings_team_anomaly_detection.tf
+++ b/settings_team_anomaly_detection.tf
@@ -462,19 +462,19 @@ resource "dynatrace_metric_events" "team_step_functions_execution_duration" {
   enabled = true
   summary = "TEAM Step Functions Execution Duration Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nStep function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} normal behavior.\nStep function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
-    event_type  = "ERROR"
+    event_type  = "SLOWDOWN"
     title       = "TEAM Step Functions Execution Duration Alert"
   }
   model_properties {
-    type               = "STATIC_THRESHOLD"
+    type               = "AUTO_ADAPTIVE_THRESHOLD"
     alert_condition    = "ABOVE"
-    threshold          = 8
     alert_on_no_data   = false
     violating_samples  = 1
     samples            = 3
     dealerting_samples = 3
+    signal_fluctuation = 1
   }
   query_definition {
     type            = "METRIC_SELECTOR"


### PR DESCRIPTION
# Description:
An alert for a step function was being raised and I realised it should be changed from static to auto adaptive threshold.

## Ticket number:
[PSREGOV-2251](https://govukverify.atlassian.net/browse/PSREGOV-2251)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[PSREGOV-2251]: https://govukverify.atlassian.net/browse/PSREGOV-2251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ