### PR TITLE
PSREGOV 2250 - Remove DynamoDB capacity alerts

### DIFF
--- a/settings_team_anomaly_detection.tf
+++ b/settings_team_anomaly_detection.tf
@@ -631,7 +631,7 @@ resource "dynatrace_metric_events" "team_policy_lambda_error" {
     Dead-letter queue details: {dims}.
 
     If assistance is needed, please reach out to #di-aws-control-tower or follow
-     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync
+    the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync
     EOT
 
     davis_merge = true
@@ -697,7 +697,7 @@ resource "dynatrace_metric_events" "team_policy_dlq_messages" {
     Dead-letter queue details: {dims}.
 
     If assistance is needed, please reach out to #di-aws-control-tower or follow
-     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync
+    the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync
     EOT
 
     davis_merge = true

--- a/settings_team_anomaly_detection.tf
+++ b/settings_team_anomaly_detection.tf
@@ -255,31 +255,6 @@ resource "dynatrace_metric_events" "team_appsync_unsubscribe_server_error" {
 }
 
 # DynamoDB
-resource "dynatrace_metric_events" "team_dynamodb_read_capacity_consumption" {
-  count   = local.is_production ? 1 : 0
-  enabled = true
-  summary = "TEAM DynamoDB Read Capacity Consumption Alert"
-  event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
-    davis_merge = true
-    event_type  = "RESOURCE"
-    title       = "TEAM DynamoDB Read Capacity Consumption Alert"
-  }
-  model_properties {
-    type               = "AUTO_ADAPTIVE_THRESHOLD"
-    alert_condition    = "ABOVE"
-    alert_on_no_data   = false
-    violating_samples  = 1
-    samples            = 3
-    dealerting_samples = 3
-    signal_fluctuation = 1
-  }
-  query_definition {
-    type            = "METRIC_SELECTOR"
-    metric_selector = "cloud.aws.dynamodb.consumedReadCapacityUnitsByAccountIdRegionTableName:filter(and(contains(\"tablename\",\"-main\")), eq(\"aws.account.id\",${var.team_account_id})):splitBy(tablename):sort(value(auto,descending)):limit(20)"
-  }
-}
-
 resource "dynatrace_metric_events" "team_dynamodb_read_throttles" {
   count   = local.is_production ? 1 : 0
   enabled = true
@@ -327,31 +302,6 @@ resource "dynatrace_metric_events" "team_dynamodb_user_error" {
   query_definition {
     type            = "METRIC_SELECTOR"
     metric_selector = "cloud.aws.dynamodb.userErrorsByAccountIdRegion:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", ${var.team_account_id}))):splitBy(\"tablename\"):sort(value(auto,descending)):limit(20)"
-  }
-}
-
-resource "dynatrace_metric_events" "team_dynamodb_write_capacity_consumption" {
-  count   = local.is_production ? 1 : 0
-  enabled = true
-  summary = "TEAM DynamoDB Write Capacity Consumption Alert"
-  event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
-    davis_merge = true
-    event_type  = "RESOURCE"
-    title       = "TEAM DynamoDB Write Capacity Consumption Alert"
-  }
-  model_properties {
-    type               = "AUTO_ADAPTIVE_THRESHOLD"
-    alert_condition    = "ABOVE"
-    alert_on_no_data   = false
-    violating_samples  = 1
-    samples            = 3
-    dealerting_samples = 3
-    signal_fluctuation = 1
-  }
-  query_definition {
-    type            = "METRIC_SELECTOR"
-    metric_selector = "cloud.aws.dynamodb.consumedWriteCapacityUnitsByAccountIdRegionTableName:filter(and(or(contains(\"tablename\",\"-main\")),eq(\"aws.account.id\", ${var.team_account_id}))):splitBy(\"tablename\"):sort(value(auto,descending)):limit(20)"
   }
 }
 

--- a/settings_team_anomaly_detection.tf
+++ b/settings_team_anomaly_detection.tf
@@ -8,7 +8,14 @@ resource "dynatrace_metric_events" "team_amplify_5xx_errors" {
   enabled = true
   summary = "TEAM Amplify 5xx Errors Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAmplify details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Amplify details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Amplify 5xx Errors Alert"
@@ -33,7 +40,14 @@ resource "dynatrace_metric_events" "team_amplify_high_latency" {
   enabled = true
   summary = "TEAM Amplify High Latency Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\n\nAmplify details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} normal behavior.
+
+    Amplify details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Amplify High Latency Alert"
@@ -59,7 +73,14 @@ resource "dynatrace_metric_events" "team_appsync_connect_client_error" {
   enabled = true
   summary = "TEAM Appsync Connect Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Appsync details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Connect Client Error Alert"
@@ -84,7 +105,14 @@ resource "dynatrace_metric_events" "team_appsync_connect_server_error" {
   enabled = true
   summary = "TEAM Appsync Connect Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Appsync details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Connect Client Server Alert"
@@ -109,7 +137,14 @@ resource "dynatrace_metric_events" "team_appsync_disconnect_client_error" {
   enabled = true
   summary = "TEAM Appsync Disconnect Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Appsync details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Disconnect Client Error Alert"
@@ -134,7 +169,14 @@ resource "dynatrace_metric_events" "team_appsync_disconnect_server_error" {
   enabled = true
   summary = "TEAM Appsync Disconnect Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    Appsync details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Disconnect Client Server Alert"
@@ -159,7 +201,14 @@ resource "dynatrace_metric_events" "team_appsync_subscribe_client_error" {
   enabled = true
   summary = "TEAM Appsync Subscribe Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Appsync details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Subscribe Client Error Alert"
@@ -184,7 +233,14 @@ resource "dynatrace_metric_events" "team_appsync_subscribe_server_error" {
   enabled = true
   summary = "TEAM Appsync Subscribe Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Appsync details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Subscribe Server Error Alert"
@@ -209,7 +265,14 @@ resource "dynatrace_metric_events" "team_appsync_unsubscribe_client_error" {
   enabled = true
   summary = "TEAM Appsync Unsubscribe Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Appsync details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Unsubscribe Client Error Alert"
@@ -234,7 +297,14 @@ resource "dynatrace_metric_events" "team_appsync_unsubscribe_server_error" {
   enabled = true
   summary = "TEAM Appsync Unsubscribe Sever Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    Appsync details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Unsubscribe Sever Error Alert"
@@ -260,7 +330,14 @@ resource "dynatrace_metric_events" "team_dynamodb_read_throttles" {
   enabled = true
   summary = "TEAM DynamoDB Read Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} normal behavior.
+    
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM DynamoDB Read Throttle Alert"
@@ -285,7 +362,14 @@ resource "dynatrace_metric_events" "team_dynamodb_user_error" {
   enabled = true
   summary = "TEAM DynamoDB User Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM DynamoDB User Error Alert"
@@ -310,7 +394,14 @@ resource "dynatrace_metric_events" "team_dynamodb_write_throttles" {
   enabled = true
   summary = "TEAM DynamoDB Write Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} normal behavior.
+    
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM DynamoDB Write Throttle Alert"
@@ -335,7 +426,14 @@ resource "dynatrace_metric_events" "team_dynamodb_server_error" {
   enabled = true
   summary = "TEAM DynamoDB Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM DynamoDB Server Error Alert"
@@ -361,7 +459,14 @@ resource "dynatrace_metric_events" "team_lambda_error" {
   enabled = true
   summary = "TEAM Lambda Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nLambda function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    Lambda function details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Lambda Error Alert"
@@ -386,7 +491,14 @@ resource "dynatrace_metric_events" "team_lambda_throttles" {
   enabled = true
   summary = "TEAM Lambda Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nLambda function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    Lambda function details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Lambda Throttle Alert"
@@ -412,7 +524,14 @@ resource "dynatrace_metric_events" "team_step_functions_execution_duration" {
   enabled = true
   summary = "TEAM Step Functions Execution Duration Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\n\nStep function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} normal behavior.
+
+    Step function details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Step Functions Execution Duration Alert"
@@ -437,7 +556,14 @@ resource "dynatrace_metric_events" "team_step_functions_execution_aborted" {
   enabled = true
   summary = "TEAM Step Functions Execution Aborted Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nStep function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    Step function details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Step Functions Execution Aborted Alert"
@@ -462,7 +588,14 @@ resource "dynatrace_metric_events" "team_step_functions_execution_failed" {
   enabled = true
   summary = "TEAM Step Functions Execution Failed Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nStep function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Step function details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Step Functions Execution Failed Alert"
@@ -498,7 +631,7 @@ resource "dynatrace_metric_events" "team_policy_lambda_error" {
     Dead-letter queue details: {dims}.
 
     If assistance is needed, please reach out to #di-aws-control-tower or follow
-     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync"
+     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync
     EOT
 
     davis_merge = true
@@ -525,7 +658,14 @@ resource "dynatrace_metric_events" "team_policy_lambda_throttles" {
   enabled = true
   summary = "TEAM Policy Publishing Function Lambda Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nLambda function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    Lambda function details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Policy Publishing Function Lambda Throttle Alert"
@@ -557,7 +697,7 @@ resource "dynatrace_metric_events" "team_policy_dlq_messages" {
     Dead-letter queue details: {dims}.
 
     If assistance is needed, please reach out to #di-aws-control-tower or follow
-     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync"
+     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync
     EOT
 
     davis_merge = true
@@ -585,7 +725,14 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_approvers_server_error"
   enabled = true
   summary = "TEAM Policy Publishing Function Approvers Table Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Policy Publishing Function Approvers Table Server Error Alert"
@@ -610,7 +757,14 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_eligibility_server_erro
   enabled = true
   summary = "TEAM Policy Publishing Function Eligibility Table Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Policy Publishing Function Eligibility Table Server Error Alert"
@@ -635,7 +789,14 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_approvers_throttles" {
   enabled = true
   summary = "TEAM Policy Publishing Function Approvers Table User Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Policy Publishing Function Approvers Table User Throttle Alert"
@@ -660,7 +821,14 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_eligibility_throttles" 
   enabled = true
   summary = "TEAM Policy Publishing Function Eligibility Table Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+    
+    DynamoDB details: {dims}.
+    
+    If assistance is needed, please reach out to #di-aws-control-tower.
+    EOT
+
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Policy Publishing Function Eligibility Table Throttle Alert"

--- a/settings_team_anomaly_detection.tf
+++ b/settings_team_anomaly_detection.tf
@@ -8,7 +8,7 @@ resource "dynatrace_metric_events" "team_amplify_5xx_errors" {
   enabled = true
   summary = "TEAM Amplify 5xx Errors Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAmplify details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAmplify details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Amplify 5xx Errors Alert"
@@ -33,7 +33,7 @@ resource "dynatrace_metric_events" "team_amplify_high_latency" {
   enabled = true
   summary = "TEAM Amplify High Latency Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\nAmplify details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} normal behavior.\n\nAmplify details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Amplify High Latency Alert"
@@ -59,7 +59,7 @@ resource "dynatrace_metric_events" "team_appsync_connect_client_error" {
   enabled = true
   summary = "TEAM Appsync Connect Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Connect Client Error Alert"
@@ -84,7 +84,7 @@ resource "dynatrace_metric_events" "team_appsync_connect_server_error" {
   enabled = true
   summary = "TEAM Appsync Connect Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Connect Client Server Alert"
@@ -109,7 +109,7 @@ resource "dynatrace_metric_events" "team_appsync_disconnect_client_error" {
   enabled = true
   summary = "TEAM Appsync Disconnect Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Disconnect Client Error Alert"
@@ -134,7 +134,7 @@ resource "dynatrace_metric_events" "team_appsync_disconnect_server_error" {
   enabled = true
   summary = "TEAM Appsync Disconnect Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Disconnect Client Server Alert"
@@ -159,7 +159,7 @@ resource "dynatrace_metric_events" "team_appsync_subscribe_client_error" {
   enabled = true
   summary = "TEAM Appsync Subscribe Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Subscribe Client Error Alert"
@@ -184,7 +184,7 @@ resource "dynatrace_metric_events" "team_appsync_subscribe_server_error" {
   enabled = true
   summary = "TEAM Appsync Subscribe Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Subscribe Server Error Alert"
@@ -209,7 +209,7 @@ resource "dynatrace_metric_events" "team_appsync_unsubscribe_client_error" {
   enabled = true
   summary = "TEAM Appsync Unsubscribe Client Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Unsubscribe Client Error Alert"
@@ -234,7 +234,7 @@ resource "dynatrace_metric_events" "team_appsync_unsubscribe_server_error" {
   enabled = true
   summary = "TEAM Appsync Unsubscribe Sever Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nAppsync details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nAppsync details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Appsync Unsubscribe Sever Error Alert"
@@ -260,7 +260,7 @@ resource "dynatrace_metric_events" "team_dynamodb_read_capacity_consumption" {
   enabled = true
   summary = "TEAM DynamoDB Read Capacity Consumption Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "RESOURCE"
     title       = "TEAM DynamoDB Read Capacity Consumption Alert"
@@ -285,7 +285,7 @@ resource "dynatrace_metric_events" "team_dynamodb_read_throttles" {
   enabled = true
   summary = "TEAM DynamoDB Read Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM DynamoDB Read Throttle Alert"
@@ -310,7 +310,7 @@ resource "dynatrace_metric_events" "team_dynamodb_user_error" {
   enabled = true
   summary = "TEAM DynamoDB User Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM DynamoDB User Error Alert"
@@ -335,7 +335,7 @@ resource "dynatrace_metric_events" "team_dynamodb_write_capacity_consumption" {
   enabled = true
   summary = "TEAM DynamoDB Write Capacity Consumption Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "RESOURCE"
     title       = "TEAM DynamoDB Write Capacity Consumption Alert"
@@ -360,7 +360,7 @@ resource "dynatrace_metric_events" "team_dynamodb_write_throttles" {
   enabled = true
   summary = "TEAM DynamoDB Write Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} normal behavior.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM DynamoDB Write Throttle Alert"
@@ -385,7 +385,7 @@ resource "dynatrace_metric_events" "team_dynamodb_server_error" {
   enabled = true
   summary = "TEAM DynamoDB Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM DynamoDB Server Error Alert"
@@ -411,7 +411,7 @@ resource "dynatrace_metric_events" "team_lambda_error" {
   enabled = true
   summary = "TEAM Lambda Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nLambda function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nLambda function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Lambda Error Alert"
@@ -436,7 +436,7 @@ resource "dynatrace_metric_events" "team_lambda_throttles" {
   enabled = true
   summary = "TEAM Lambda Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nLambda function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nLambda function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Lambda Throttle Alert"
@@ -462,7 +462,7 @@ resource "dynatrace_metric_events" "team_step_functions_execution_duration" {
   enabled = true
   summary = "TEAM Step Functions Execution Duration Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} normal behavior.\nStep function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} normal behavior.\n\nStep function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Step Functions Execution Duration Alert"
@@ -487,7 +487,7 @@ resource "dynatrace_metric_events" "team_step_functions_execution_aborted" {
   enabled = true
   summary = "TEAM Step Functions Execution Aborted Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nStep function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nStep function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Step Functions Execution Aborted Alert"
@@ -512,7 +512,7 @@ resource "dynatrace_metric_events" "team_step_functions_execution_failed" {
   enabled = true
   summary = "TEAM Step Functions Execution Failed Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nStep function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nStep function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Step Functions Execution Failed Alert"
@@ -542,7 +542,15 @@ resource "dynatrace_metric_events" "team_policy_lambda_error" {
   enabled = true
   summary = "TEAM Policy Publishing Function Lambda Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nLambda function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Dead-letter queue details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower or follow
+     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync"
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Policy Publishing Function Lambda Error Alert"
@@ -567,7 +575,7 @@ resource "dynatrace_metric_events" "team_policy_lambda_throttles" {
   enabled = true
   summary = "TEAM Policy Publishing Function Lambda Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nLambda function details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nLambda function details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Policy Publishing Function Lambda Throttle Alert"
@@ -593,7 +601,15 @@ resource "dynatrace_metric_events" "team_policy_dlq_messages" {
   enabled = true
   summary = "TEAM Policy Publishing Function DLQ Message Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nDead-letter queue details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = <<-EOT
+    The {metricname} value was {alert_condition} {threshold}.
+
+    Dead-letter queue details: {dims}.
+
+    If assistance is needed, please reach out to #di-aws-control-tower or follow
+     the runbook at https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5286527019/T.E.A.M+Policy+resync"
+    EOT
+
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Policy Publishing Function DLQ Message Alert"
@@ -619,7 +635,7 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_approvers_server_error"
   enabled = true
   summary = "TEAM Policy Publishing Function Approvers Table Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Policy Publishing Function Approvers Table Server Error Alert"
@@ -644,7 +660,7 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_eligibility_server_erro
   enabled = true
   summary = "TEAM Policy Publishing Function Eligibility Table Server Error Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "ERROR"
     title       = "TEAM Policy Publishing Function Eligibility Table Server Error Alert"
@@ -669,7 +685,7 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_approvers_throttles" {
   enabled = true
   summary = "TEAM Policy Publishing Function Approvers Table User Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Policy Publishing Function Approvers Table User Throttle Alert"
@@ -694,7 +710,7 @@ resource "dynatrace_metric_events" "team_policy_dynamodb_eligibility_throttles" 
   enabled = true
   summary = "TEAM Policy Publishing Function Eligibility Table Throttle Alert"
   event_template {
-    description = "The {metricname} value was {alert_condition} {threshold}.\nDynamoDB details: {dims}.\nIf assistance is needed, please reach out to #di-aws-control-tower."
+    description = "The {metricname} value was {alert_condition} {threshold}.\n\nDynamoDB details: {dims}.\n\nIf assistance is needed, please reach out to #di-aws-control-tower."
     davis_merge = true
     event_type  = "SLOWDOWN"
     title       = "TEAM Policy Publishing Function Eligibility Table Throttle Alert"


### PR DESCRIPTION
# Description:
- Updated alert description format
- Removed dynamodb capacity alerts as these don't seem to be useful

## Ticket number:
[PSREGOV-2250](https://govukverify.atlassian.net/browse/PSREGOV-2250)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[PSREGOV-2250]: https://govukverify.atlassian.net/browse/PSREGOV-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ