### PR TITLE
New modules for muted and key requests

### DIFF
--- a/modules/service_key_requests/main.tf
+++ b/modules/service_key_requests/main.tf
@@ -1,0 +1,4 @@
+resource "dynatrace_key_requests" "key_requests" {
+  service = var.key_requests_service
+  names   = var.key_requests_names
+}

--- a/modules/service_key_requests/provider.tf
+++ b/modules/service_key_requests/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    dynatrace = {
+      source  = "dynatrace-oss/dynatrace"
+      version = "~> 1.62"
+    }
+  }
+}

--- a/modules/service_key_requests/variables.tf
+++ b/modules/service_key_requests/variables.tf
@@ -1,0 +1,8 @@
+variable "key_requests_service" {
+  description = "The ID of the Service that the key requests should be applied to"
+}
+
+variable "key_requests_names" {
+  description = "A set of values to be marked as key requests against the Service"
+  type        = set(string)
+}

--- a/modules/service_muted_requests/main.tf
+++ b/modules/service_muted_requests/main.tf
@@ -1,0 +1,4 @@
+resource "dynatrace_muted_requests" "muted_requests" {
+  service_id          = var.muted_requests_service_id
+  muted_request_names = var.muted_requests_names
+}

--- a/modules/service_muted_requests/provider.tf
+++ b/modules/service_muted_requests/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    dynatrace = {
+      source  = "dynatrace-oss/dynatrace"
+      version = "~> 1.62"
+    }
+  }
+}

--- a/modules/service_muted_requests/variables.tf
+++ b/modules/service_muted_requests/variables.tf
@@ -1,0 +1,8 @@
+variable "muted_requests_service_id" {
+  description = "The ID of the Service that the muted requests should be applied to"
+}
+
+variable "muted_requests_names" {
+  description = "A set of values to be marked as muted requests against the Service"
+  type        = set(string)
+}

--- a/services_key_requests.tf
+++ b/services_key_requests.tf
@@ -1,0 +1,5 @@
+# module "blah" {
+#   source               = "./modules/service_key_requests"
+#   key_requests_names   = ""
+#   key_requests_service = ""
+# }

--- a/services_muted_requests.tf
+++ b/services_muted_requests.tf
@@ -1,0 +1,5 @@
+# module "blah" {
+#   source                    = "./modules/service_muted_requests"
+#   muted_requests_names      = ""
+#   muted_requests_service_id = ""
+# }


### PR DESCRIPTION
# Description:
Added two new modules, one for service muted requests and another for service key requests. Placeholders created for users to copy/paste in the main .tf files.

## Ticket number:
PSREGOV-2524

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
