### PR TITLE
[DCMAW-12597] Remove cloned overlapped tile causing dashboard not to deploy

### DIFF
--- a/dashboards/id-check/dcmaw-frontend-api-gateway.json
+++ b/dashboards/id-check/dcmaw-frontend-api-gateway.json
@@ -4,7 +4,7 @@
       7
     ],
     "clusterVersion": "1.315.45.20250530-125212"
-  },  
+  },
   "dashboardMetadata": {
     "name": "MOBILE - DCMAW FE - API Gateway",
     "shared": true,


### PR DESCRIPTION
# Description:
ID Check FE API dashboard was failing to deploy, remove an overlapped tile. I was able to add this to prod manually to test.
## Ticket number:
[DCMAW-12597]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[DCMAW-12597]: https://govukverify.atlassian.net/browse/DCMAW-12597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ