### PR TITLE
Rs/disable signin browser monitor and team client disconnect error

### DIFF
--- a/monitors.tf
+++ b/monitors.tf
@@ -13,13 +13,13 @@ module "oidc-jwks-monitor" {
   domain_name = each.value
 }
 
-module "signin-browser-monitor" {
-  source = "./modules/monitors/sign-in"
+# module "signin-browser-monitor" {
+#   source = "./modules/monitors/sign-in"
 
-  domain_name              = var.environment == "production" ? "home.account.gov.uk" : "home.integration.account.gov.uk"
-  environment              = var.environment == "production" ? "production" : "integration"
-  use_basic_authentication = var.environment != "production"
-}
+#   domain_name              = var.environment == "production" ? "home.account.gov.uk" : "home.integration.account.gov.uk"
+#   environment              = var.environment == "production" ? "production" : "integration"
+#   use_basic_authentication = var.environment != "production"
+# }
 
 module "webchat-browser-monitor" {
   source = "./modules/monitors/webchat"

--- a/settings_team_anomaly_detection.tf
+++ b/settings_team_anomaly_detection.tf
@@ -134,7 +134,7 @@ resource "dynatrace_metric_events" "team_appsync_connect_server_error" {
 
 resource "dynatrace_metric_events" "team_appsync_disconnect_client_error" {
   count   = local.is_production ? 1 : 0
-  enabled = true
+  enabled = false
   summary = "TEAM Appsync Disconnect Client Error Alert"
   event_template {
     description = <<-EOT


### PR DESCRIPTION
# Description:
- Temporarily disabling the monitoring OTP script, which is failing and blocking other PRs from being merged
- Turn off the TEAM AppSync Client Disconnect Error alert, as we are seeing dozens per day and currently have no way fo actioning them so want to reduce noise

## Ticket number:

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
