### PR TITLE
DCMAW-13833: add 2XX graph and table to mobile ID check async BE api gateway dashboard

### DIFF
--- a/dashboards/id-check/async-backend-api-gateway.json
+++ b/dashboards/id-check/async-backend-api-gateway.json
@@ -9,7 +9,7 @@
     "name": "MOBILE - ID CHECK ASYNC BE - API Gateway",
     "shared": true,
     "owner": "matthew.barber@digital.cabinet-office.gov.uk",
-    "popularity": 3,
+    "popularity": 9,
     "hasConsistentColors": false
   },
   "tiles": [
@@ -32,9 +32,9 @@
       "tileType": "HEADER",
       "configured": true,
       "bounds": {
-        "top": 38,
-        "left": 38,
-        "width": 304,
+        "top": 76,
+        "left": 0,
+        "width": 760,
         "height": 38
       },
       "tileFilter": {},
@@ -280,20 +280,6 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 76,
-        "left": 1444,
-        "width": 304,
-        "height": 418
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "markdown": "CloudWatch comparisons for data accuracy\n\n[Tile 1](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#metricsV2?graph=~(metrics~(~(~'AWS*2fApiGateway~'Count~'ApiName~'mob-async-backend-private-api)~(~'...~'mob-async-backend-sessions-api))~sparkline~false~view~'table~stacked~false~region~'eu-west-2~start~'-PT1H~end~'P0D~stat~'Sum~period~60)&query=~'*7bAWS*2fApiGateway*2cApiName*7d)\n\n[Tile 2](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#metricsV2?graph=~(metrics~(~(~'AWS*2fApiGateway~'Latency~'ApiName~'mob-async-backend-private-api)~(~'...~'mob-async-backend-proxy-api)~(~'.~'Count~'.~'mob-async-backend-private-api~'Resource~'*2fasync*2ftoken~'Stage~'build~'Method~'POST)~(~'...~'*2fasync*2fcredential~'.~'.~'.~'.)~(~'...~'mob-async-backend-sessions-api~'.~'*2fasync*2fbiometricToken~'.~'.~'.~'.)~(~'...~'*2fasync*2ffinishBiometricSession~'.~'.~'.~'.)~(~'...~'*2fasync*2fabortSession~'.~'.~'.~'.)~(~'...~'*2f.well-known*2fjwks.json~'.~'.~'.~'GET)~(~'...~'*2fasync*2factiveSession~'.~'.~'.~'.)~(~'...~'*2fasync*2ftxmaEvent~'.~'.~'.~'POST))~sparkline~false~view~'table~stacked~false~region~'eu-west-2~start~'-PT24H~end~'P0D~stat~'Sum~period~300)&query=~'*7bAWS*2fApiGateway*2cApiName*2cMethod*2cResource*2cStage*7d*20count) \n\n[Tile 3](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#metricsV2?graph=~(metrics~(~(~'AWS*2fApiGateway~'Latency~'ApiName~'mob-async-backend-private-api~(visible~false))~(~'...~'mob-async-backend-proxy-api~(visible~false))~(~'.~'Count~'.~'mob-async-backend-private-api~'Resource~'*2fasync*2ftoken~'Stage~'build~'Method~'POST)~(~'...~'*2fasync*2fcredential~'.~'.~'.~'.)~(~'...~'mob-async-backend-sessions-api~'.~'*2fasync*2fbiometricToken~'.~'.~'.~'.)~(~'...~'*2fasync*2ffinishBiometricSession~'.~'.~'.~'.)~(~'...~'*2fasync*2fabortSession~'.~'.~'.~'.)~(~'...~'*2f.well-known*2fjwks.json~'.~'.~'.~'GET)~(~'...~'*2fasync*2factiveSession~'.~'.~'.~'.)~(~'...~'*2fasync*2ftxmaEvent~'.~'.~'.~'POST))~sparkline~false~view~'timeSeries~stacked~false~region~'eu-west-2~start~'-PT24H~end~'P0D~stat~'Sum~period~300)&query=~'*7bAWS*2fApiGateway*2cApiName*2cMethod*2cResource*2cStage*7d*20count)\n\n[Tile 4](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#metricsV2?graph=~(sparkline~false~metrics~(~(~'AWS*2fApiGateway~'Count~'ApiName~'mob-async-backend-private-api)~(~'...~'mob-async-backend-sessions-api))~view~'timeSeries~stacked~false~region~'eu-west-2~start~'-PT1H~end~'P0D~stat~'Sum~period~60)&query=~'*7bAWS*2fApiGateway*2cApiName*7d)\n\n[Tile 5](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#metricsV2?graph=~(metrics~(~(~'AWS*2fApiGateway~'Count~'ApiName~'mob-async-backend-private-api~'Resource~'*2fasync*2ftoken~'Stage~'build~'Method~'POST)~(~'...~'*2fasync*2fcredential~'.~'.~'.~'.)~(~'...~'mob-async-backend-sessions-api~'.~'*2fasync*2fbiometricToken~'.~'.~'.~'.)~(~'...~'*2fasync*2ffinishBiometricSession~'.~'.~'.~'.)~(~'...~'*2f.well-known*2fjwks.json~'.~'.~'.~'GET)~(~'...~'*2fasync*2factiveSession~'.~'.~'.~'.)~(~'...~'*2fasync*2ftxmaEvent~'.~'.~'.~'POST)~(~'...~'*2fasync*2fabortSession~'.~'.~'.~'.))~sparkline~false~view~'table~stacked~false~region~'eu-west-2~start~'2025-04-07T00*3a00*3a00.000Z~end~'2025-05-22T13*3a04*3a00.000Z~stat~'Sum~period~604800)&query=~'*7bAWS*2fApiGateway*2cApiName*2cMethod*2cResource*2cStage*7d*20count)"
-    },
-    {
-      "name": "Markdown",
-      "tileType": "MARKDOWN",
-      "configured": true,
-      "bounds": {
         "top": 3230,
         "left": 38,
         "width": 304,
@@ -360,14 +346,14 @@
       "markdown": "Average Transactions Per Second over the past 30 days\n\n[Average](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#metricsV2?graph=~(metrics~(~(~'AWS*2fApiGateway~'Count~'ApiName~'id-check-cri-backend-api~(id~'m1)))~sparkline~false~view~'table~stacked~false~region~'eu-west-2~start~'-PT720H~end~'P0D~period~21600~stat~'Sum~title~'Top*2010*20queues*20by*20age*20of*20oldest*20message~yAxis~(left~(label~'Count~showUnits~false)))&query=~'*7bAWS*2fApiGateway*2cApiName*7d)"
     },
     {
-      "name": "3: Request Count Per Endpoint - PERF006",
+      "name": "2: Request Count Per Endpoint - PERF006",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 266,
-        "left": 38,
+        "top": 76,
+        "left": 760,
         "width": 760,
-        "height": 342
+        "height": 380
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -2475,11 +2461,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "mob-async-backend-sessions-api",
+                    "value": "mob-async-backend-private-api",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "mob-async-backend-private-api",
+                    "value": "mob-async-backend-sessions-api",
                     "evaluator": "EQ"
                   }
                 ]
@@ -2581,7 +2567,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-sessions-api),eq(apiname,mob-async-backend-private-api)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-sessions-api),eq(apiname,mob-async-backend-private-api)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):names,(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,mob-async-backend-sessions-api),eq(apiname,mob-async-backend-private-api)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):names"
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-private-api),eq(apiname,mob-async-backend-sessions-api)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-private-api),eq(apiname,mob-async-backend-sessions-api)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):names,(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,mob-async-backend-private-api),eq(apiname,mob-async-backend-sessions-api)))):splitBy(apiname):sum:sort(value(sum,descending)):limit(20)):names"
       ]
     },
     {
@@ -2589,10 +2575,10 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 494,
-        "left": 798,
-        "width": 950,
-        "height": 418
+        "top": 76,
+        "left": 2128,
+        "width": 1064,
+        "height": 760
       },
       "tileFilter": {
         "timeframe": "now\\0w-1w to now\\0w-0w"
@@ -2907,11 +2893,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "mob-async-backend-sessions-api",
+                    "value": "mob-async-backend-private-api",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "mob-async-backend-private-api",
+                    "value": "mob-async-backend-sessions-api",
                     "evaluator": "EQ"
                   }
                 ]
@@ -2944,11 +2930,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "mob-async-backend-private-api",
+                    "value": "mob-async-backend-sessions-api",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "mob-async-backend-sessions-api",
+                    "value": "mob-async-backend-private-api",
                     "evaluator": "EQ"
                   }
                 ]
@@ -3030,170 +3016,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-sessions-api),eq(apiname,mob-async-backend-private-api)))):splitBy(resource,apiname):sum:sort(value(sum,descending)):limit(20)):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-sessions-api),eq(apiname,mob-async-backend-private-api)))):splitBy(resource,apiname):sum:sort(value(sum,descending)):limit(20)):names"
-      ]
-    },
-    {
-      "name": "2: Request Count Per Endpoint",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 76,
-        "left": 798,
-        "width": 646,
-        "height": 418
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Table",
-      "queries": [
-        {
-          "id": "F",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "resource",
-            "apiname"
-          ],
-          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(\"apiname\",\"mob-async-backend-sessions-api\"),or(eq(\"apiname\",\"mob-async-backend-private-api\")))):splitBy(\"resource\",\"apiname\"):sum:sort(value(avg,descending)):limit(20)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "TABLE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "F:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "columnId": "Count",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "F",
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1001,
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1001,
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1001,
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          },
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "value": 0,
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "value": 1001,
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "isThresholdBackgroundAppliedToCell": true,
-          "hiddenColumns": [
-            "A:resource.name",
-            "B:resource.name",
-            "C:resource.name",
-            "D:resource.name",
-            "E:resource.name",
-            "F:resource.name",
-            "F:apiname.name"
-          ]
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,mob-async-backend-sessions-api),or(eq(apiname,mob-async-backend-private-api)))):splitBy(resource,apiname):sum:sort(value(avg,descending)):limit(20)):names"
+        "resolution=Inf&(cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-private-api),eq(apiname,mob-async-backend-sessions-api)))):splitBy(resource,apiname):sum:sort(value(sum,descending)):limit(20)):names,(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":filter(and(or(eq(apiname,mob-async-backend-private-api),eq(apiname,mob-async-backend-sessions-api)))):splitBy(resource,apiname):sum:sort(value(sum,descending)):limit(20)):names"
       ]
     },
     {
@@ -3202,9 +3025,9 @@
       "configured": true,
       "bounds": {
         "top": 0,
-        "left": 722,
-        "width": 722,
-        "height": 76
+        "left": 0,
+        "width": 912,
+        "height": 38
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -3544,14 +3367,14 @@
       ]
     },
     {
-      "name": "1: Request Count",
+      "name": "1a: Request Count",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 76,
-        "left": 38,
+        "top": 114,
+        "left": 0,
         "width": 760,
-        "height": 190
+        "height": 228
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -3637,14 +3460,14 @@
       ]
     },
     {
-      "name": "4: Request Count - PERF006",
+      "name": "1b: Request Count - PERF006",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 608,
-        "left": 38,
+        "top": 342,
+        "left": 0,
         "width": 760,
-        "height": 304
+        "height": 494
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -4628,6 +4451,338 @@
       },
       "metricExpressions": [
         "resolution=Inf&(cloud.aws.apigateway.latencyByAccountIdApiIdMethodRegionResourceStage:filter(and(or(eq(apiid,\"8v38aag7bb\"),or(eq(apiid,g3rygde4f5)),or(eq(apiid,\"5k4wjdc10e\")),or(eq(apiid,\"8dlyplgsi6\")),or(eq(apiid,ryarifl4h7))))):splitBy(apiid):avg:sort(value(avg,descending)):limit(20)):names,(cloud.aws.apigateway.latencyByAccountIdApiIdMethodRegionResourceStage:filter(and(or(eq(apiid,\"8v38aag7bb\"),or(eq(apiid,g3rygde4f5)),or(eq(apiid,\"5k4wjdc10e\")),or(eq(apiid,\"8dlyplgsi6\")),or(eq(apiid,ryarifl4h7))))):splitBy(apiid):max:sort(value(min,descending)):limit(20)):names"
+      ]
+    },
+    {
+      "name": "3: 2XX Count Per Endpoint",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 456,
+        "left": 760,
+        "width": 760,
+        "height": 380
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Table",
+      "queries": [
+        {
+          "id": "L",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:sum:filter(eq(\"resource\", \"/async/activeSession\")) - (cloud.aws.apigateway.4xxErrorByAccountIdApiNameMethodRegionResourceStage:sum:filter(eq(\"resource\", \"/async/activeSession\")) + cloud.aws.apigateway.5xxErrorByAccountIdApiNameMethodRegionResourceStage:sum:filter(eq(\"resource\", \"/async/activeSession\")) )",
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "M",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:sum:splitBy(\"resource\") - (cloud.aws.apigateway.4xxErrorByAccountIdApiNameMethodRegionResourceStage:sum:splitBy(\"resource\") + cloud.aws.apigateway.5xxErrorByAccountIdApiNameMethodRegionResourceStage:sum:splitBy(\"resource\") )",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "L:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "M:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "F",
+                "G",
+                "I",
+                "K",
+                "L",
+                "M"
+              ],
+              "defaultAxis": true
+            },
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "RIGHT",
+              "queryIds": [
+                "H",
+                "J"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Count",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "F",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1001,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1001,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1001,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          },
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 0,
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1001,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "isThresholdBackgroundAppliedToCell": true,
+          "hiddenColumns": [
+            "A:resource.name",
+            "B:resource.name",
+            "C:resource.name",
+            "D:resource.name",
+            "E:resource.name",
+            "F:resource.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:sum:splitBy(resource)-(cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":sum:splitBy(resource)+cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":sum:splitBy(resource))):limit(100):names"
+      ]
+    },
+    {
+      "name": "4: Request Count Per Endpoint",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 76,
+        "left": 1520,
+        "width": 608,
+        "height": 760
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Table",
+      "queries": [
+        {
+          "id": "G",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource",
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:splitBy(\"resource\",\"apiname\"):sum:sort(value(avg,descending))",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "J",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "resource",
+            "apiname"
+          ],
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:splitBy(\"resource\",\"apiname\"):sum - ( cloud.aws.apigateway.4xxErrorByAccountIdApiNameMethodRegionResourceStage:splitBy(\"resource\",\"apiname\"):sum + cloud.aws.apigateway.5xxErrorByAccountIdApiNameMethodRegionResourceStage:splitBy(\"resource\",\"apiname\"):sum )",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "G:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "J:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "2XX"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "Count",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "G",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "isThresholdBackgroundAppliedToCell": true,
+          "hiddenColumns": [
+            "G:resource.name",
+            "G:apiname.name",
+            "J:resource.name",
+            "J:apiname.name",
+            "H:resource.name",
+            "H:apiname.name",
+            "I:resource.name",
+            "I:apiname.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:splitBy(resource,apiname):sum:sort(value(avg,descending))):names,(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:splitBy(resource,apiname):sum - (cloud.aws.apigateway.\"4xxErrorByAccountIdApiNameMethodRegionResourceStage\":splitBy(resource,apiname):sum+cloud.aws.apigateway.\"5xxErrorByAccountIdApiNameMethodRegionResourceStage\":splitBy(resource,apiname):sum)):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
Adds a 2XX graph and column to request count table to display 2XX count per endpoint

## Ticket number:
[DCMAW-13833](https://govukverify.atlassian.net/browse/DCMAW-13833)

Dynatrace Dashboard in Build
![Screenshot 2025-06-11 at 13 57 57](https://github.com/user-attachments/assets/3ffecf3b-49f1-4547-8e67-3ac506acec7d)

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
