### PR TITLE
FPAD-5339: Show number of messages for each queue in Dynatrace SQS Widgets

### DIFF
--- a/documents/fpad/fpad-infrastructure.json
+++ b/documents/fpad/fpad-infrastructure.json
@@ -3208,10 +3208,10 @@
     },
     "57": { "type": "markdown", "content": "## SQS Metrics" },
     "62": {
-      "title": "New Messages Sent",
+      "title": "Messages Sent",
       "description": "",
       "type": "data",
-      "query": "timeseries numberOfMessagesSentByAccountIdQueueNameRegion=avg(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion),\nby: { tablename },\nfilter: { aws.account.id == $SelectedAWSAccount }",
+      "query": "timeseries { count(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion),\nvalue.A = avg(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion, scalar: true) },\nby: { queuename },\nfilter: { aws.account.id == $SelectedAWSAccount }",
       "visualization": "lineChart",
       "visualizationSettings": {
         "thresholds": [],
@@ -3245,7 +3245,9 @@
           ],
           "fieldMapping": {
             "timestamp": "timeframe",
-            "leftAxisValues": ["numberOfMessagesSentByAccountIdQueueNameRegion"]
+            "leftAxisValues": [
+              "count(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion)"
+            ]
           },
           "leftYAxisSettings": {
             "isLabelVisible": true,
@@ -3269,13 +3271,7 @@
           "monospacedFontEnabled": false,
           "monospacedFontColumns": [],
           "columnWidths": {},
-          "columnTypeOverrides": [
-            {
-              "fields": ["numberOfMessagesSentByAccountIdQueueNameRegion"],
-              "value": "sparkline",
-              "id": 1751032735818
-            }
-          ]
+          "columnTypeOverrides": []
         },
         "honeycomb": {
           "shape": "hexagon",
@@ -3319,9 +3315,9 @@
       }
     },
     "63": {
-      "title": "New Messages Received",
+      "title": "Messages Received",
       "type": "data",
-      "query": "timeseries numberOfMessagesReceivedByAccountIdQueueNameRegion=avg(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion),\nby: { tablename },\nfilter: { aws.account.id == $SelectedAWSAccount }",
+      "query": "timeseries { count(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion),\nvalue.A = avg(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion, scalar: true) },\nby: { queuename },\nfilter: { aws.account.id == $SelectedAWSAccount }",
       "visualization": "lineChart",
       "visualizationSettings": {
         "thresholds": [],
@@ -3356,7 +3352,7 @@
           "fieldMapping": {
             "timestamp": "timeframe",
             "leftAxisValues": [
-              "numberOfMessagesReceivedByAccountIdQueueNameRegion"
+              "count(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion)"
             ]
           },
           "leftYAxisSettings": {
@@ -3383,9 +3379,11 @@
           "columnWidths": {},
           "columnTypeOverrides": [
             {
-              "fields": ["numberOfMessagesReceivedByAccountIdQueueNameRegion"],
+              "fields": [
+                "count(cloud.aws.sqs.numberOfMessagesReceivedByAccountIdQueueNameRegion)"
+              ],
               "value": "sparkline",
-              "id": 1751026310599
+              "id": 1751971518402
             }
           ]
         },
@@ -3431,9 +3429,9 @@
       }
     },
     "64": {
-      "title": "New Messages Visible",
+      "title": "Messages Visible",
       "type": "data",
-      "query": "timeseries approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion=avg(cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion),\nfilter: { aws.account.id == $SelectedAWSAccount }",
+      "query": "timeseries { count(cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion),\nvalue.A = avg(cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion, scalar: true) },\nby: { queuename },\nfilter: { aws.account.id == $SelectedAWSAccount }",
       "visualization": "lineChart",
       "visualizationSettings": {
         "thresholds": [],
@@ -3468,7 +3466,7 @@
           "fieldMapping": {
             "timestamp": "timeframe",
             "leftAxisValues": [
-              "approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion"
+              "count(cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion)"
             ]
           },
           "leftYAxisSettings": {
@@ -3496,10 +3494,10 @@
           "columnTypeOverrides": [
             {
               "fields": [
-                "approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion"
+                "count(cloud.aws.sqs.approximateNumberOfMessagesVisibleByAccountIdQueueNameRegion)"
               ],
               "value": "sparkline",
-              "id": 1751026434481
+              "id": 1751973931892
             }
           ]
         },
@@ -3545,9 +3543,9 @@
       }
     },
     "65": {
-      "title": "New Messages not visible",
+      "title": "Messages not visible",
       "type": "data",
-      "query": "timeseries approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion=avg(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion),\nfilter: { aws.account.id == $SelectedAWSAccount }",
+      "query": "timeseries { count(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion),\nvalue.A = avg(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion, scalar: true) },\nby: { queuename },\nfilter: { aws.account.id == $SelectedAWSAccount }",
       "visualization": "lineChart",
       "visualizationSettings": {
         "thresholds": [],
@@ -3582,7 +3580,7 @@
           "fieldMapping": {
             "timestamp": "timeframe",
             "leftAxisValues": [
-              "approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion"
+              "count(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion)"
             ]
           },
           "leftYAxisSettings": {
@@ -3610,10 +3608,10 @@
           "columnTypeOverrides": [
             {
               "fields": [
-                "approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion"
+                "count(cloud.aws.sqs.approximateNumberOfMessagesNotVisibleByAccountIdQueueNameRegion)"
               ],
               "value": "sparkline",
-              "id": 1751026521826
+              "id": 1751973982525
             }
           ]
         },


### PR DESCRIPTION
# Description:

## Ticket number:
[FPAD-5339]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[FPAD-5339]: https://govukverify.atlassian.net/browse/FPAD-5339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ