### PR TITLE
OJ-3197 - Include metrics pushed by the NinoCheckFunction in HMRC latency graphs

### DIFF
--- a/dashboards/orange/check-hmrc-lambda-metrics.json
+++ b/dashboards/orange/check-hmrc-lambda-metrics.json
@@ -6933,23 +6933,15 @@
                 ]
               },
               {
-                "filter": "aws.region",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "eu-west-2",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
                 "nestedFilters": [],
                 "criteria": [
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "evaluator": "EQ"
+                  },
                   {
                     "value": "di-ipv-cri-check-hmrc-api-Matching",
                     "evaluator": "EQ"
@@ -6995,6 +6987,10 @@
                   {
                     "value": "di-ipv-cri-check-hmrc-api-Matching",
                     "evaluator": "EQ"
+                  },
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "evaluator": "EQ"
                   }
                 ]
               }
@@ -7036,6 +7032,10 @@
                 "criteria": [
                   {
                     "value": "di-ipv-cri-check-hmrc-api-Matching",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
                     "evaluator": "EQ"
                   }
                 ]
@@ -7150,7 +7150,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(\"aws.region\",eu-west-2)),or(eq(http,MatchingHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-Matching)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,MatchingHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-Matching)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,MatchingHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-Matching)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(service,di-ipv-cri-check-hmrc-api-Matching),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)),or(eq(http,MatchingHandler)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(service,di-ipv-cri-check-hmrc-api-Matching),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)),or(eq(http,MatchingHandler)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(service,di-ipv-cri-check-hmrc-api-Matching),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)),or(eq(http,MatchingHandler)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -7179,18 +7179,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "http",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "OTGHandler",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -7198,6 +7186,22 @@
                 "criteria": [
                   {
                     "value": "di-ipv-cri-check-hmrc-api-OTG",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "http",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "OTGHandler",
                     "evaluator": "EQ"
                   }
                 ]
@@ -7239,6 +7243,10 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "evaluator": "EQ"
+                  },
+                  {
                     "value": "di-ipv-cri-check-hmrc-api-OTG",
                     "evaluator": "EQ"
                   }
@@ -7263,6 +7271,22 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
+                "filter": "service",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-OTG",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
                 "filter": "http",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -7270,18 +7294,6 @@
                 "criteria": [
                   {
                     "value": "OTGHandler",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
-                "filter": "service",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "di-ipv-cri-check-hmrc-api-OTG",
                     "evaluator": "EQ"
                   }
                 ]
@@ -7396,7 +7408,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-OTG)),or(eq(http,OTGHandler)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

With the conversion of the NINo Check logic from a step function to a Lambda function, we are finding that the metrics are now pushed with a different 'service' dimension. This change adds the new dimension to the 'OR' statements in our HMRC API graphs to ensure continuity of metrics across the transition.

## Ticket number:

- OJ-3197

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:
