### PR TITLE
OJ-3197 - Revert unit transform to auto for HMRC API plots

### DIFF
--- a/dashboards/orange/check-hmrc-lambda-metrics.json
+++ b/dashboards/orange/check-hmrc-lambda-metrics.json
@@ -7054,7 +7054,7 @@
         "rules": [
           {
             "matcher": "A:",
-            "unitTransform": "Kilo",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "YELLOW",
@@ -7065,7 +7065,7 @@
           },
           {
             "matcher": "B:",
-            "unitTransform": "Kilo",
+            "unitTransform": "auto",
             "valueFormat": "none",
             "properties": {
               "color": "RED",
@@ -7076,7 +7076,7 @@
           },
           {
             "matcher": "C:",
-            "unitTransform": "Kilo",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "GREEN",
@@ -7312,7 +7312,7 @@
         "rules": [
           {
             "matcher": "A:",
-            "unitTransform": "Kilo",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "YELLOW",
@@ -7323,7 +7323,7 @@
           },
           {
             "matcher": "B:",
-            "unitTransform": "Kilo",
+            "unitTransform": "auto",
             "valueFormat": "none",
             "properties": {
               "color": "RED",
@@ -7334,7 +7334,7 @@
           },
           {
             "matcher": "C:",
-            "unitTransform": "Kilo",
+            "unitTransform": "auto",
             "valueFormat": "0",
             "properties": {
               "color": "GREEN",


### PR DESCRIPTION
# Description:

Resolves an issue where the reported numeric API latencies are not easy to see:

<img width="570" height="239" alt="image" src="https://github.com/user-attachments/assets/e7a7790c-f8fe-440f-a273-39eb582587f6" />

## Ticket number:
- OJ-3197

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:
