### PR TITLE
AUT-4373: Add owner metadata to auth account management dashboards

### DIFF
--- a/dashboards/authentication/account-management/authentication-account-management-integration.json
+++ b/dashboards/authentication/account-management/authentication-account-management-integration.json
@@ -8,6 +8,7 @@
   "dashboardMetadata": {
     "name": "Authentication - Account Management (Integration)",
     "shared": true,
+    "owner": "authentication-developers@digital.cabinet-office.gov.uk",
     "hasConsistentColors": false
   },
   "tiles": [

--- a/dashboards/authentication/account-management/authentication-account-management-production.json
+++ b/dashboards/authentication/account-management/authentication-account-management-production.json
@@ -8,6 +8,7 @@
   "dashboardMetadata": {
     "name": "Authentication - Account Management (Production)",
     "shared": true,
+    "owner": "authentication-developers@digital.cabinet-office.gov.uk",
     "hasConsistentColors": false
   },
   "tiles": [

--- a/dashboards/authentication/account-management/authentication-account-management-staging.json
+++ b/dashboards/authentication/account-management/authentication-account-management-staging.json
@@ -8,6 +8,7 @@
   "dashboardMetadata": {
     "name": "Authentication - Account Management (Staging)",
     "shared": true,
+    "owner": "authentication-developers@digital.cabinet-office.gov.uk",
     "hasConsistentColors": false
   },
   "tiles": [


### PR DESCRIPTION
# Description

The new dashboard for authentication account management metrics added in #474 is missing "owner" metadata which is leading to a deployment failure.

This PR adds this to each of the files for this dashboard.

The re-upload to Dynatrace unfortunately didn't catch this so hoping this fixes it. Have reuploaded the files to check the web ui is happy with them still.

## Ticket number
[AUT-4373](https://govukverify.atlassian.net/browse/AUT-4373) - Create Dynatrace dashboard for monitoring method management

## Checklist
- [ ] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment: Re-uploaded the exported JSON files to Dynatrace without any issues, [comment with screenshots here](https://govukverify.atlassian.net/browse/AUT-4373?focusedCommentId=241613)
- [ ] Documentation added (link) Comment: **- N/A**


[AUT-4373]: https://govukverify.atlassian.net/browse/AUT-4373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ