### PR TITLE
OJ-3249: Add JWT Verification Failure tile

### DIFF
--- a/dashboards/orange/address-lambda-metrics.json
+++ b/dashboards/orange/address-lambda-metrics.json
@@ -4009,11 +4009,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -4287,11 +4287,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "address-cri-api-v1-PublicAddressApi",
+                    "value": "address-cri-api-v1-PrivateAddressApi",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "address-cri-api-v1-PrivateAddressApi",
+                    "value": "address-cri-api-v1-PublicAddressApi",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5060,18 +5060,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "service",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "di-ipv-cri-address-api-postcode-lookup",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "aws.region",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5079,6 +5067,18 @@
                 "criteria": [
                   {
                     "value": "eu-west-2",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "service",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "di-ipv-cri-address-api-postcode-lookup",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5102,18 +5102,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "service",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "di-ipv-cri-address-api-postcode-lookup",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "aws.region",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5121,6 +5109,18 @@
                 "criteria": [
                   {
                     "value": "eu-west-2",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "service",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "di-ipv-cri-address-api-postcode-lookup",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5144,18 +5144,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "service",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "di-ipv-cri-address-api-postcode-lookup",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "aws.region",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5163,6 +5151,18 @@
                 "criteria": [
                   {
                     "value": "eu-west-2",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "service",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "di-ipv-cri-address-api-postcode-lookup",
                     "evaluator": "EQ"
                   }
                 ]
@@ -6115,6 +6115,100 @@
       "metricExpressions": [
         "resolution=Inf&(cloud.aws.di-ipv-cri-address-api.jwt_expiredByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20)):limit(100):names",
         "resolution=null&(cloud.aws.di-ipv-cri-address-api.jwt_expiredByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "JWT Verification Failures",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1330,
+        "left": 1444,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.di-ipv-cri-address-api.jwt_verification_failedByAccountIdRegionservice",
+          "spaceAggregation": "COUNT",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "nestedFilters": [],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.di-ipv-cri-address-api.jwt_verification_failedByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.di-ipv-cri-address-api.jwt_verification_failedByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20))"
       ]
     }
   ]

--- a/dashboards/orange/check-hmrc-lambda-metrics.json
+++ b/dashboards/orange/check-hmrc-lambda-metrics.json
@@ -3856,11 +3856,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "check-hmrc-cri-api-public",
+                    "value": "check-hmrc-cri-api-private",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "check-hmrc-cri-api-private",
+                    "value": "check-hmrc-cri-api-public",
                     "evaluator": "EQ"
                   }
                 ]
@@ -3976,11 +3976,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "check-hmrc-cri-api-private",
+                    "value": "check-hmrc-cri-api-public",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "check-hmrc-cri-api-public",
+                    "value": "check-hmrc-cri-api-private",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5593,18 +5593,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "http",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "MatchingHandler",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5616,6 +5604,18 @@
                   },
                   {
                     "value": "di-ipv-cri-check-hmrc-api-Matching",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "http",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "MatchingHandler",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5691,11 +5691,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-Matching",
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "value": "di-ipv-cri-check-hmrc-api-Matching",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5851,18 +5851,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "http",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "OTGHandler",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5874,6 +5862,18 @@
                   },
                   {
                     "value": "di-ipv-cri-check-hmrc-api-OTG",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "http",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "OTGHandler",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5949,11 +5949,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-OTG",
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "value": "di-ipv-cri-check-hmrc-api-OTG",
                     "evaluator": "EQ"
                   }
                 ]
@@ -6176,6 +6176,100 @@
       "metricExpressions": [
         "resolution=Inf&(cloud.aws.di-ipv-cri-check-hmrc-api.jwt_expiredByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20)):limit(100):names",
         "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.jwt_expiredByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "JWT Verification Failures",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1938,
+        "left": 1444,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "JWT Verification Failures",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.di-ipv-cri-check-hmrc-api.jwt_verification_failedByAccountIdRegionservice",
+          "spaceAggregation": "COUNT",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "nestedFilters": [],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.di-ipv-cri-check-hmrc-api.jwt_verification_failedByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.jwt_verification_failedByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20))"
       ]
     }
   ]

--- a/dashboards/orange/experian-kbv-lambda-metrics.json
+++ b/dashboards/orange/experian-kbv-lambda-metrics.json
@@ -3515,11 +3515,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "kbv-cri-private-kbv-cri-api-v1",
+                    "value": "kbv-cri-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "kbv-cri-kbv-cri-api-v1",
+                    "value": "kbv-cri-private-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   }
                 ]
@@ -3635,11 +3635,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "kbv-cri-private-kbv-cri-api-v1",
+                    "value": "kbv-cri-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "kbv-cri-kbv-cri-api-v1",
+                    "value": "kbv-cri-private-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5001,18 +5001,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "aws.region",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "eu-west-2",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5020,6 +5008,18 @@
                 "criteria": [
                   {
                     "value": "di-ipv-cri-kbv-api-question",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "aws.region",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "eu-west-2",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5282,18 +5282,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "aws.region",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "eu-west-2",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5301,6 +5289,18 @@
                 "criteria": [
                   {
                     "value": "di-ipv-cri-kbv-api-answer",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
+                "filter": "aws.region",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "eu-west-2",
                     "evaluator": "EQ"
                   }
                 ]
@@ -5748,6 +5748,100 @@
       "metricExpressions": [
         "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.jwt_expiredByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20)):limit(100):names",
         "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.jwt_expiredByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20))"
+      ]
+    },
+    {
+      "name": "JWT Verification Failures",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1102,
+        "left": 1444,
+        "width": 304,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "JWT Verification Failures",
+      "queries": [
+        {
+          "id": "A",
+          "metric": "cloud.aws.di-ipv-cri-kbv-api.jwt_verification_failedByAccountIdRegionservice",
+          "spaceAggregation": "COUNT",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "sortBy": "DESC",
+          "sortByDimension": "",
+          "filterBy": {
+            "nestedFilters": [],
+            "criteria": []
+          },
+          "limit": 20,
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.di-ipv-cri-kbv-api.jwt_verification_failedByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20)):limit(100):names",
+        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.jwt_verification_failedByAccountIdRegionservice:splitBy():count:sort(value(avg,descending)):limit(20))"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Added JWT Verification Failure tile to Orange CRI lambda dashboards.

## Ticket number:
[OJ-3249]

## Screenshot

<img width="1513" height="618" alt="image" src="https://github.com/user-attachments/assets/75f6f984-09c5-4583-86ec-3495ba00f2af" />


[OJ-3249]: https://govukverify.atlassian.net/browse/OJ-3249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ