### PR TITLE
SPT-1534: Updated SPOT Key Rotations dashboard

### DIFF
--- a/dashboards/spot/key-rotation-dashboard.json
+++ b/dashboards/spot/key-rotation-dashboard.json
@@ -39,7 +39,7 @@
             "kmsid",
             "kid"
           ],
-          "metricSelector": "cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId\n:splitBy(kmsid,kid)\n:sum\n:sort(value(sum,descending))",
+          "metricSelector": "cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId\n:splitBy(kmsid,kid)\n:sum\n:sort(value(sum,descending))\n:default(0, always) + cloud.aws.spot.identitySignedByAccountIdLogGroupRegionServiceNameServiceTypekidkmsId\n:splitBy(kmsid,kid)\n:sum\n:sort(value(sum,descending))\n:default(0, always)",
           "rate": "NONE",
           "enabled": true
         }
@@ -114,7 +114,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy(kmsid,kid):sum:sort(value(sum,descending))):limit(100):names"
+        "resolution=null&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy(kmsid,kid):sum:sort(value(sum,descending)):default(0,always)+cloud.aws.spot.identitySignedByAccountIdLogGroupRegionServiceNameServiceTypekidkmsId:splitBy(kmsid,kid):sum:sort(value(sum,descending)):default(0,always)):limit(100):names"
       ]
     },
     {
@@ -244,7 +244,7 @@
             "kmsid",
             "kid"
           ],
-          "metricSelector": "cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId\n:splitBy(\"kmsid\", \"kid\")\n:lastReal\n:sum",
+          "metricSelector": "cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId\n:splitBy(\"kmsid\", \"kid\")\n:lastReal\n:sum\n:default(0, always) + cloud.aws.spot.identitySignedByAccountIdLogGroupRegionServiceNameServiceTypekidkmsId\n:splitBy(\"kmsid\", \"kid\")\n:lastReal\n:sum\n:default(0, always)",
           "rate": "NONE",
           "enabled": true
         }
@@ -315,7 +315,7 @@
         "foldAggregation": "SUM"
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy(kmsid,kid):lastReal:sum):limit(100):names:fold(sum)"
+        "resolution=null&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy(kmsid,kid):lastReal:sum:default(0,always)+cloud.aws.spot.identitySignedByAccountIdLogGroupRegionServiceNameServiceTypekidkmsId:splitBy(kmsid,kid):lastReal:sum:default(0,always)):limit(100):names:fold(sum)"
       ]
     },
     {


### PR DESCRIPTION
# Description:

Updated SPOT Key Rotations dashboard as due to a recent change to AWS Powertools new dimensions have now been added changing the name of the metric selector. The updated selectors combine the old and new metrics to create a composite value.

## Ticket number:
[SPT-1534: SPOT: Metrics Powertools Java Upgrade](https://govukverify.atlassian.net/browse/SPT-1534)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence - Supports both a new and old selectors
- [x] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment: N/A

<img width="1624" height="1056" alt="Screenshot 2025-08-08 at 11 53 19" src="https://github.com/user-attachments/assets/9205164d-0c88-431e-9ba8-47d82814f08a" />
