### PR TITLE
SPT-1534:Dynatrace dashboard changes

### DIFF
--- a/dashboards/spot/spot-performance-metrics.json
+++ b/dashboards/spot/spot-performance-metrics.json
@@ -490,7 +490,7 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [],
-          "metricSelector": "cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId\n:splitBy()\n:sum",
+          "metricSelector": "cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId\n:splitBy()\n:sum\n:default(0,always)+cloud.aws.spot.identitySignedByAccountIdLogGroupRegionServiceNameServiceTypekidkmsId\n:splitBy()\n:sum\n:default(0,always)",
           "rate": "NONE",
           "enabled": true
         }
@@ -557,8 +557,8 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy():sum):limit(100):names",
-        "resolution=null&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy():sum)"
+        "resolution=null&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy():sum:default(0,always)+cloud.aws.spot.identitySignedByAccountIdLogGroupRegionServiceNameServiceTypekidkmsId:splitBy():sum:default(0,always)):limit(100):names:fold(auto)",
+        "resolution=null&(cloud.aws.spot.identitySignedByAccountIdRegionkidkmsId:splitBy():sum:default(0,always)+cloud.aws.spot.identitySignedByAccountIdLogGroupRegionServiceNameServiceTypekidkmsId:splitBy():sum:default(0,always))"
       ]
     },
     {
@@ -653,7 +653,7 @@
         "foldAggregation": "SUM"
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence:splitBy(levelofconfidence):sum:sort(value(sum,descending)):limit(20)):limit(100):names:fold(sum)"
+        "resolution=null&(cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence:splitBy(levelofconfidence):sum:sort(value(sum,descending)):limit(20):default(0,always)+cloud.aws.spot.identityIssuedByAccountIdLogGroupRegionServiceNameServiceTypegpg45ProfilelevelOfConfidence:splitBy(levelofconfidence):sum:sort(value(sum,descending)):limit(20):default(0,always)):limit(100):names:fold(sum)"
       ]
     },
     {
@@ -677,7 +677,7 @@
           "splitBy": [
             "gpg45profile"
           ],
-          "metricSelector": "cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence\n:splitBy(gpg45profile)\n:sum:sort(value(sum,descending))",
+          "metricSelector": "cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence\n:splitBy(gpg45profile)\n:sum:sort(value(sum,descending))\n:default(0,always)+cloud.aws.spot.identityIssuedByAccountIdLogGroupRegionServiceNameServiceTypegpg45ProfilelevelOfConfidence\n:splitBy(gpg45profile)\n:sum:sort(value(sum,descending))\n:default(0,always)",
           "rate": "NONE",
           "enabled": true
         }
@@ -741,7 +741,7 @@
         "foldAggregation": "SUM"
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence:splitBy(gpg45profile):sum:sort(value(sum,descending))):limit(100):names:fold(sum)"
+        "resolution=null&(cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence:splitBy(gpg45profile):sum:sort(value(sum,descending)):default(0,always)+cloud.aws.spot.identityIssuedByAccountIdLogGroupRegionServiceNameServiceTypegpg45ProfilelevelOfConfidence:splitBy(gpg45profile):sum:sort(value(sum,descending)):default(0,always)):limit(100):names:fold(sum)"
       ]
     },
     {
@@ -765,7 +765,7 @@
           "splitBy": [
             "gpg45profile"
           ],
-          "metricSelector": "cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence\n:splitBy(gpg45profile)\n:sum\n:sort(value(sum,descending))",
+          "metricSelector": "cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence\n:splitBy(gpg45profile)\n:sum\n:sort(value(sum,descending))\n:default(0,always)+cloud.aws.spot.identityIssuedByAccountIdLogGroupRegionServiceNameServiceTypegpg45ProfilelevelOfConfidence\n:splitBy(gpg45profile)\n:sum\n:sort(value(sum,descending))\n:default(0,always)",
           "rate": "NONE",
           "enabled": true
         }
@@ -840,7 +840,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence:splitBy(gpg45profile):sum:sort(value(sum,descending))):limit(100):names"
+        "resolution=null&(cloud.aws.spot.identityIssuedByAccountIdRegiongpg45ProfilelevelOfConfidence:splitBy(gpg45profile):sum:sort(value(sum,descending)):default(0,always)+cloud.aws.spot.identityIssuedByAccountIdLogGroupRegionServiceNameServiceTypegpg45ProfilelevelOfConfidence:splitBy(gpg45profile):sum:sort(value(sum,descending)):default(0,always)):limit(100):names"
       ]
     },
     {
@@ -1416,7 +1416,7 @@
             "gpg45profile",
             "reason"
           ],
-          "metricSelector": "cloud.aws.spot.conditionalProfileAllowedByAccountIdRegiongpg45Profilereason\n:splitBy(\"gpg45profile\",\"reason\")\n:sum\n:sort(value(auto,descending))",
+          "metricSelector": "cloud.aws.spot.conditionalProfileAllowedByAccountIdRegiongpg45Profilereason\n:splitBy(\"gpg45profile\",\"reason\")\n:sum\n:sort(value(auto,descending))\n:default(0,always)+cloud.aws.spot.conditionalProfileAllowedByAccountIdLogGroupRegionServiceNameServiceTypegpg45Profilereason\n:splitBy(\"gpg45profile\",\"reason\")\n:sum\n:sort(value(auto,descending))\n:default(0,always)",
           "rate": "NONE",
           "enabled": true
         }
@@ -1475,7 +1475,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=Inf&(cloud.aws.spot.conditionalProfileAllowedByAccountIdRegiongpg45Profilereason:splitBy(gpg45profile,reason):sum:sort(value(auto,descending))):limit(100):names"
+        "resolution=null&(cloud.aws.spot.conditionalProfileAllowedByAccountIdRegiongpg45Profilereason:splitBy(gpg45profile,reason):sum:sort(value(auto,descending)):default(0,always)+cloud.aws.spot.conditionalProfileAllowedByAccountIdLogGroupRegionServiceNameServiceTypegpg45Profilereason:splitBy(gpg45profile,reason):sum:sort(value(auto,descending)):default(0,always)):limit(100):names:fold(auto)"
       ]
     },
     {


### PR DESCRIPTION
# Description:

Updated SPOT Key Rotations dashboard as due to a recent change to AWS Powertools new dimensions have now been added changing the name of the metric selector. The updated selectors combine the old and new metrics to create a composite value.

This updates the tiles for Spot performance metrics for sections Signed Responses Sent/Profiles Issued/Level of Confidence Issued/ Profiles Issued over time/Conditional Profiles Allowed
## Ticket number:
[SPT-1534: SPOT: Metrics Powertools Java Upgrade](https://govukverify.atlassian.net/browse/SPT-1534)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence - Supports both a new and old selectors
- [x] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment: N/A

<img width="1221" height="618" alt="Screenshot 2025-08-11 at 12 41 22" src="https://github.com/user-attachments/assets/6d4c0a69-2690-411f-b143-b7344892a925" />

