### PR TITLE
Updated WAF blocked requests alert config

### DIFF
--- a/settings_anomaly_detection.tf
+++ b/settings_anomaly_detection.tf
@@ -353,7 +353,7 @@ resource "dynatrace_metric_events" "waf_blocked_requests" {
     WAF details: {dims}.
     EOT
 
-    davis_merge = true
+    davis_merge = false
     event_type  = "ERROR"
     title       = "WAF Blocked Requests Alert"
   }
@@ -364,6 +364,7 @@ resource "dynatrace_metric_events" "waf_blocked_requests" {
     violating_samples  = 50
     samples            = 60
     dealerting_samples = 60
+    signal_fluctuation = 10
   }
   query_definition {
     type            = "METRIC_SELECTOR"


### PR DESCRIPTION
# Description:
Updated the WAF blocked requests alert config to ensure that it only fires when the value is 10x greater than the norm

## Ticket number:
PSREGOV-2947

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
