### PR TITLE
ATO-1944: Add authorize requests tiles to orch dashboards

### DIFF
--- a/dashboards/orchestration/general_non_prod.json
+++ b/dashboards/orchestration/general_non_prod.json
@@ -7,7 +7,7 @@
     },
     "dashboardMetadata": {
       "name": "Orchestration - General (non-prod)",
-      "shared": false,
+      "shared": true,
       "owner": "craig.earl@digital.cabinet-office.gov.uk",
       "hasConsistentColors": false
     },

--- a/dashboards/orchestration/general_prod.json
+++ b/dashboards/orchestration/general_prod.json
@@ -7,7 +7,7 @@
   },
   "dashboardMetadata": {
     "name": "Orchestration - General",
-    "shared": false,
+    "shared": true,
     "owner": "craig.earl@digital.cabinet-office.gov.uk",
     "hasConsistentColors": false
   },


### PR DESCRIPTION
# Description:
Adds a new tile to the orchestration dashboards to display /authorize requests by RP

## Ticket number:
[ATO-1944]

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[ATO-1944]: https://govukverify.atlassian.net/browse/ATO-1944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ