### PR TITLE
OJ-3294 - Update step function name; merge accounts & regions

### DIFF
--- a/dashboards/orange/experian-kbv-cri.json
+++ b/dashboards/orange/experian-kbv-cri.json
@@ -3334,7 +3334,7 @@
             "dt.entity.cloud:aws:account",
             "dt.entity.cloud:aws:region"
           ],
-          "metricSelector": "cloud.aws.states.executionsStartedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStateMachine\")):sum:merge(\"statemachinearn\")",
+          "metricSelector": "cloud.aws.states.executionsStartedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStepFunction\")):sum:merge(\"statemachinearn\"):merge(\"aws.account.id\"):merge(\"dt.entity.cloud:aws:account\"):merge(\"aws.region\"):merge(\"dt.entity.cloud:aws:region\")",
           "rate": "NONE",
           "enabled": true
         },
@@ -3348,7 +3348,7 @@
             "dt.entity.cloud:aws:account",
             "dt.entity.cloud:aws:region"
           ],
-          "metricSelector": "cloud.aws.states.executionsSucceededByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStateMachine\")):sum:merge(\"statemachinearn\")",
+          "metricSelector": "cloud.aws.states.executionsSucceededByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStepFunction\")):sum:merge(\"statemachinearn\"):merge(\"aws.account.id\"):merge(\"dt.entity.cloud:aws:account\"):merge(\"aws.region\"):merge(\"dt.entity.cloud:aws:region\")",
           "rate": "NONE",
           "enabled": true
         },
@@ -3362,7 +3362,7 @@
             "dt.entity.cloud:aws:account",
             "dt.entity.cloud:aws:region"
           ],
-          "metricSelector": "cloud.aws.states.executionsFailedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStateMachine\")):sum:merge(\"statemachinearn\")",
+          "metricSelector": "cloud.aws.states.executionsFailedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStepFunction\")):sum:merge(\"statemachinearn\"):merge(\"aws.account.id\"):merge(\"dt.entity.cloud:aws:account\"):merge(\"aws.region\"):merge(\"dt.entity.cloud:aws:region\")",
           "rate": "NONE",
           "enabled": true
         },
@@ -3376,7 +3376,7 @@
             "dt.entity.cloud:aws:account",
             "dt.entity.cloud:aws:region"
           ],
-          "metricSelector": "cloud.aws.states.executionsAbortedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStateMachine\")):sum:merge(\"statemachinearn\")",
+          "metricSelector": "cloud.aws.states.executionsAbortedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStepFunction\")):sum:merge(\"statemachinearn\"):merge(\"aws.account.id\"):merge(\"dt.entity.cloud:aws:account\"):merge(\"aws.region\"):merge(\"dt.entity.cloud:aws:region\")",
           "rate": "NONE",
           "enabled": true
         },
@@ -3390,7 +3390,7 @@
             "dt.entity.cloud:aws:account",
             "dt.entity.cloud:aws:region"
           ],
-          "metricSelector": "cloud.aws.states.executionsTimedOutByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStateMachine\")):sum:merge(\"statemachinearn\")",
+          "metricSelector": "cloud.aws.states.executionsTimedOutByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,\"CertificateExpiryStepFunction\")):sum:merge(\"statemachinearn\"):merge(\"aws.account.id\"):merge(\"dt.entity.cloud:aws:account\"):merge(\"aws.region\"):merge(\"dt.entity.cloud:aws:region\")",
           "rate": "NONE",
           "enabled": true
         }
@@ -3517,7 +3517,7 @@
         "resolution": "1d"
       },
       "metricExpressions": [
-        "resolution=1d&(cloud.aws.states.executionsStartedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStateMachine)):sum:merge(statemachinearn)):limit(100):names,(cloud.aws.states.executionsSucceededByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStateMachine)):sum:merge(statemachinearn)):limit(100):names,(cloud.aws.states.executionsFailedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStateMachine)):sum:merge(statemachinearn)):limit(100):names,(cloud.aws.states.executionsAbortedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStateMachine)):sum:merge(statemachinearn)):limit(100):names,(cloud.aws.states.executionsTimedOutByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStateMachine)):sum:merge(statemachinearn)):limit(100):names"
+        "resolution=1d&(cloud.aws.states.executionsStartedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStepFunction)):sum:merge(statemachinearn):merge(aws.account.id):merge(dt.entity.cloud:aws:account):merge(aws.region):merge(dt.entity.cloud:aws:region)):limit(100):names,(cloud.aws.states.executionsSucceededByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStepFunction)):sum:merge(statemachinearn):merge(aws.account.id):merge(dt.entity.cloud:aws:account):merge(aws.region):merge(dt.entity.cloud:aws:region)):limit(100):names,(cloud.aws.states.executionsFailedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStepFunction)):sum:merge(statemachinearn):merge(aws.account.id):merge(dt.entity.cloud:aws:account):merge(aws.region):merge(dt.entity.cloud:aws:region)):limit(100):names,(cloud.aws.states.executionsAbortedByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStepFunction)):sum:merge(statemachinearn):merge(aws.account.id):merge(dt.entity.cloud:aws:account):merge(aws.region):merge(dt.entity.cloud:aws:region)):limit(100):names,(cloud.aws.states.executionsTimedOutByAccountIdRegionStateMachineArn:filter(contains(statemachinearn,CertificateExpiryStepFunction)):sum:merge(statemachinearn):merge(aws.account.id):merge(dt.entity.cloud:aws:account):merge(aws.region):merge(dt.entity.cloud:aws:region)):limit(100):names"
       ]
     },
     {


### PR DESCRIPTION
# Description:

- We have tweaked the name of a new step function being monitored; this PR makes that change. Backwards compatibility is not necessary as the step function is new and no-one except team Orange is checking it at the moment.
- We have also updated the metric selectors for the same plot to ensure that it sums across accounts rather than creating separate lines for each account.

Here is what the new plot looks like in a test dashboard:

<img width="1870" height="766" alt="image" src="https://github.com/user-attachments/assets/fba5adb1-a46c-4d5f-9db2-7b1186fcba26" />

## Ticket number:
- OJ-3294

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:
