### PR TITLE
OJ-3294 - Use sum instead of count; correct execution plot legend

### DIFF
--- a/dashboards/orange/experian-kbv-cri.json
+++ b/dashboards/orange/experian-kbv-cri.json
@@ -3438,7 +3438,8 @@
             "valueFormat": "auto",
             "properties": {
               "color": "RED",
-              "seriesType": "STACKED_AREA"
+              "seriesType": "STACKED_AREA",
+              "alias": "Executions aborted"
             },
             "seriesOverrides": []
           },
@@ -3448,7 +3449,8 @@
             "valueFormat": "auto",
             "properties": {
               "color": "RED",
-              "seriesType": "STACKED_AREA"
+              "seriesType": "STACKED_AREA",
+              "alias": "Executions timed out"
             },
             "seriesOverrides": [
               {
@@ -3557,7 +3559,7 @@
             "dt.entity.cloud:aws:account",
             "dt.entity.cloud:aws:region"
           ],
-          "metricSelector": "cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan90DaysByAccountIdRegion:count",
+          "metricSelector": "cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan90DaysByAccountIdRegion:sum",
           "rate": "NONE",
           "enabled": true
         }
@@ -3625,8 +3627,8 @@
         "foldTransformation": "LAST_VALUE"
       },
       "metricExpressions": [
-        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan90DaysByAccountIdRegion:count):limit(100):names:last",
-        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan90DaysByAccountIdRegion:count)"
+        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan90DaysByAccountIdRegion:sum):limit(100):names:last",
+        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan90DaysByAccountIdRegion:sum)"
       ]
     },
     {
@@ -3653,7 +3655,7 @@
             "dt.entity.cloud:aws:account",
             "dt.entity.cloud:aws:region"
           ],
-          "metricSelector": "cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan7DaysByAccountIdRegion:count",
+          "metricSelector": "cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan7DaysByAccountIdRegion:sum",
           "rate": "NONE",
           "enabled": true
         }
@@ -3721,8 +3723,8 @@
         "foldTransformation": "LAST_VALUE"
       },
       "metricExpressions": [
-        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan7DaysByAccountIdRegion:count):limit(100):names:last",
-        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan7DaysByAccountIdRegion:count)"
+        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan7DaysByAccountIdRegion:sum):limit(100):names:last",
+        "resolution=1d&(cloud.aws.di-ipv-cri-kbv-api.experianMTLSCertificateExpiryLessThan7DaysByAccountIdRegion:sum)"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Minor fixes for the KBV certificate expiry dashboard:
- Display sum, not count, on the big number metric tiles
- Minor legibility improvements to the step function execution plot legend

## Ticket number:
- [OJ-3294](https://govukverify.atlassian.net/browse/OJ-3294)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:


[OJ-3294]: https://govukverify.atlassian.net/browse/OJ-3294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ