### PR TITLE
ATO-1946 Fix tokens issued graphs on orch dashboards

### DIFF
--- a/dashboards/orchestration/general_non_prod.json
+++ b/dashboards/orchestration/general_non_prod.json
@@ -13,98 +13,6 @@
     },
     "tiles": [
       {
-        "name": "Tokens issued",
-        "tileType": "DATA_EXPLORER",
-        "configured": true,
-        "bounds": {
-          "top": 646,
-          "left": 570,
-          "width": 570,
-          "height": 304
-        },
-        "tileFilter": {},
-        "isAutoRefreshDisabled": false,
-        "customName": "Data explorer results",
-        "queries": [
-          {
-            "id": "A",
-            "spaceAggregation": "AUTO",
-            "timeAggregation": "DEFAULT",
-            "splitBy": ["clientname"],
-            "metricSelector": "cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(not(eq(\"environment\",\"production\"))):splitBy(clientname):sort(value(auto,descending)):count:value:default(0)",
-            "rate": "NONE",
-            "enabled": true
-          }
-        ],
-        "visualConfig": {
-          "type": "GRAPH_CHART",
-          "global": {},
-          "rules": [
-            {
-              "matcher": "A:",
-              "properties": {
-                "color": "DEFAULT"
-              },
-              "seriesOverrides": []
-            }
-          ],
-          "axes": {
-            "xAxis": {
-              "displayName": "",
-              "visible": true
-            },
-            "yAxes": [
-              {
-                "displayName": "",
-                "visible": true,
-                "min": "AUTO",
-                "max": "AUTO",
-                "position": "LEFT",
-                "queryIds": ["A"],
-                "defaultAxis": true
-              }
-            ]
-          },
-          "heatmapSettings": {
-            "yAxis": "VALUE"
-          },
-          "thresholds": [
-            {
-              "axisTarget": "LEFT",
-              "rules": [
-                {
-                  "color": "#7dc540"
-                },
-                {
-                  "color": "#f5d30f"
-                },
-                {
-                  "color": "#dc172a"
-                }
-              ],
-              "visible": true
-            }
-          ],
-          "tableSettings": {
-            "hiddenColumns": []
-          },
-          "graphChartSettings": {
-            "connectNulls": false
-          },
-          "honeycombSettings": {
-            "showHive": true,
-            "showLegend": true,
-            "showLabels": false
-          }
-        },
-        "queriesSettings": {
-          "resolution": ""
-        },
-        "metricExpressions": [
-          "resolution=null&(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(not(eq(environment,production))):splitBy(clientname):sort(value(auto,descending)):count:value:default(0)):limit(100):names"
-        ]
-      },
-      {
         "name": "Tokens and auth codes issued",
         "tileType": "DATA_EXPLORER",
         "configured": true,
@@ -123,7 +31,7 @@
             "spaceAggregation": "AUTO",
             "timeAggregation": "DEFAULT",
             "splitBy": [],
-            "metricSelector": "cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(not(or(eq(\"environment\",\"production\"),eq(\"environment\",\"integration\")))):splitBy():count",
+            "metricSelector": "cloud.aws.authentication.successfulTokenIssuedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(not(or(eq(\"environment\",\"production\"),eq(\"environment\",\"integration\")))):splitBy():count",
             "rate": "NONE",
             "enabled": true
           },
@@ -217,7 +125,7 @@
           "resolution": ""
         },
         "metricExpressions": [
-          "resolution=null&(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count):limit(100):names,(cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodRegionServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)+cloud.aws.authentication.docAppCallbackByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeSuccessful:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)):limit(100):names"
+          "resolution=null&(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count):limit(100):names,(cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodRegionServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)+cloud.aws.authentication.docAppCallbackByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeSuccessful:filter(not(or(eq(environment,production),eq(environment,integration)))):splitBy():count:value:default(0,always)):limit(100):names"
         ]
       },
       {

--- a/dashboards/orchestration/general_prod.json
+++ b/dashboards/orchestration/general_prod.json
@@ -31,7 +31,7 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [],
-          "metricSelector": "cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"environment\",\"production\"), eq(\"environment\",\"integration\"))):splitBy():count",
+          "metricSelector": "cloud.aws.authentication.successfulTokenIssuedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"environment\",\"production\"), eq(\"environment\",\"integration\"))):splitBy():count",
           "rate": "NONE",
           "enabled": true
         },
@@ -125,103 +125,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count):limit(100):names,(cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodRegionServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)+cloud.aws.authentication.docAppCallbackByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeSuccessful:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)):limit(100):names"
-      ]
-    },
-    {
-      "name": "Tokens issued",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 646,
-        "left": 570,
-        "width": 570,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": ["clientname"],
-          "metricSelector": "cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(environment,integration), eq(environment, production))):splitBy(clientname):count:sort(value(avg,descending))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Tokens issued"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": ["A"],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(environment,integration),eq(environment,production))):splitBy(clientname):count:sort(value(avg,descending))):limit(100):names"
+        "resolution=null&(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count):limit(100):names,(cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaMethodRegionServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)+cloud.aws.authentication.signInByAccountAccountIdClientClientNameEnvironmentIsDocAppIsTestLogGroupMfaRequiredRegionRequestedLevelOfConfidenceServiceNameServiceType:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)+cloud.aws.authentication.docAppCallbackByAccountIdEnvironmentLogGroupRegionServiceNameServiceTypeSuccessful:filter(or(eq(environment,production),eq(environment,integration))):splitBy():count:value:default(0)):limit(100):names"
       ]
     },
     {


### PR DESCRIPTION
# Description:
Context: `clientName` was previously added as a dimension to the `successfulTokenIssued` metric and the orch dashboards updated accordingly. However, changing the metric broke other dashboards so it was reverted.
- Revert orch dashboards to using the original metric for `successfulTokenIssued`, without the `clientName` dimension.
- Remove the graph showing tokens issued by RP from the orch dashboards, because this is already available in the [RP Dashboard](https://bhe21058.apps.dynatrace.com/ui/apps/dynatrace.classic.dashboards/#dashboard;gtf=-6h;gf=all;id=7ebbeb31-abe0-4dc7-a07b-46ea127c65fd)

## Ticket number:
[ATO-1946](https://govukverify.atlassian.net/browse/ATO-1946)

## Checklist:
- [X] Is my change backwards compatible? Please include evidence
- [X] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[ATO-1946]: https://govukverify.atlassian.net/browse/ATO-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ