### PR TITLE
DCMAW-15694: Fix DCMAW lambda dashboard to use latest metric dimensions

### DIFF
--- a/dashboards/id-check/dcmaw-backend-lambda.json
+++ b/dashboards/id-check/dcmaw-backend-lambda.json
@@ -84,600 +84,6 @@
       "markdown": "## Message Codes: STARTED & COMPLETED\n\nLeft column shows number of STARTED message codes per lambda function.\nRight column shows number of COMPLETED message codes per lambda function.\n"
     },
     {
-      "name": "GetRedirect-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1520,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_GET_REDIRECT_STARTED\"), eq(\"messagecode\",\"DCMAW_GET_REDIRECT_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_GET_REDIRECT_STARTED),eq(messagecode,DCMAW_GET_REDIRECT_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "OpenidConfiguration-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1976,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_OPENID_CONFIGURATION_STARTED\"), eq(\"messagecode\",\"DCMAW_OPENID_CONFIGURATION_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_OPENID_CONFIGURATION_STARTED),eq(messagecode,DCMAW_OPENID_CONFIGURATION_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "ResourceOwnerDocumentGroups-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2204,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED\"), eq(\"messagecode\",\"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED),eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "UserAbortCommand-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2432,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_USER_ABORT_COMMAND_STARTED\"), eq(\"messagecode\",\"DCMAW_USER_ABORT_COMMAND_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_USER_ABORT_COMMAND_STARTED),eq(messagecode,DCMAW_USER_ABORT_COMMAND_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "VerifyAuthorizeRequest-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2888,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED\"), eq(\"messagecode\",\"DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED),eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "WriteTxmaEvent-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3116,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_WRITE_TXMA_EVENT_STARTED\"), eq(\"messagecode\",\"DCMAW_WRITE_TXMA_EVENT_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_WRITE_TXMA_EVENT_STARTED),eq(messagecode,DCMAW_WRITE_TXMA_EVENT_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
       "name": "Markdown",
       "tileType": "MARKDOWN",
       "configured": true,
@@ -704,105 +110,6 @@
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
       "markdown": "# Traffic\n## Invocations\n\nThese graphs show the number of times each lambda function has been invoked.\n"
-    },
-    {
-      "name": "UserInfoFunction-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2660,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_STARTED\"), eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_STARTED),eq(messagecode,DCMAW_FETCH_USER_INFO_V2_COMPLETED)))):sum):limit(100):names"
-      ]
     },
     {
       "name": "FetchBiometricTokenV2-backend: Invocations",
@@ -6727,2390 +6034,6 @@
       ]
     },
     {
-      "name": "IssueAccessToken-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1748,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "E",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(not(or(eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_STARTED\"), eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED\")))):splitBy(\"messagecode\")",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "E:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "C",
-                "D",
-                "E",
-                "F"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(not(or(eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_STARTED),eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED)))):splitBy(messagecode)):limit(100):names"
-      ]
-    },
-    {
-      "name": "FetchBiometricTokenV2-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1064,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "D",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED\"), eq(\"messagecode\",\"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "D:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "C",
-                "D"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED),eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "6. AppInfo-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 836,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_APP_INFO_STARTED\"), eq(\"messagecode\",\"DCMAW_APP_INFO_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_APP_INFO_STARTED),eq(messagecode,DCMAW_APP_INFO_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "FinishBiometricSession2-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1292,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FINISH_BIOMETRIC_SESSION_STARTED\"), eq(\"messagecode\",\"DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "C",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdLevelMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_STARTED),eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
-      "name": "7b DCMAW_APP_INFO_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 836,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\",\"DCMAW_APP_INFO_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_APP_INFO_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "7a. DCMAW_APP_INFO_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 836,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_APP_INFO_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_AREA"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_APP_INFO_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1064,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_APP_INFO_STARTED\"))",
-          "rate": "NONE",
-          "enabled": false
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_AREA"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1064,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_FINISH_BIOMETRIC_SESSION_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1292,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FINISH_BIOMETRIC_SESSION_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1292,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_GET_REDIRECT_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1520,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_GET_REDIRECT_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_GET_REDIRECT_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_GET_REDIRECT_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1520,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_GET_REDIRECT_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_GET_REDIRECT_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_ISSUE_ACCESS_TOKEN_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1748,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1748,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_OPENID_CONFIGURATION_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1976,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_OPENID_CONFIGURATION_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_OPENID_CONFIGURATION_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_OPENID_CONFIGURATION_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1976,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_OPENID_CONFIGURATION_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_OPENID_CONFIGURATION_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2204,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2204,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_USER_ABORT_COMMAND_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2432,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_USER_ABORT_COMMAND_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_USER_ABORT_COMMAND_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_USER_ABORT_COMMAND_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2432,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_USER_ABORT_COMMAND_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_USER_ABORT_COMMAND_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_FETCH_USER_INFO_V2_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2660,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_USER_INFO_V2_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_FETCH_USER_INFO_V2_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2660,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_USER_INFO_V2_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2888,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2888,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_WRITE_TXMA_EVENT_STARTED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3116,
-        "left": 2280,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_WRITE_TXMA_EVENT_STARTED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_WRITE_TXMA_EVENT_STARTED))):limit(100):names"
-      ]
-    },
-    {
-      "name": "DCMAW_WRITE_TXMA_EVENT_COMPLETED",
-      "nameSize": "small",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 3116,
-        "left": 2508,
-        "width": 228,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_WRITE_TXMA_EVENT_COMPLETED\"))",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": false,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": false
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdLevelMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_WRITE_TXMA_EVENT_COMPLETED))):limit(100):names"
-      ]
-    },
-    {
       "name": "Markdown",
       "tileType": "MARKDOWN",
       "configured": true,
@@ -9752,7 +6675,7 @@
           "hideLegend": false
         },
         "rules": [
-          {
+        {
             "matcher": "D:",
             "properties": {
               "color": "DEFAULT"
@@ -10456,6 +7379,3078 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.lambda.invocationsByAccountIdFunctionNameRegion:filter(contains(functionname,\"-backend-api\")):splitBy(functionname):sum:sort(dimension(functionname,ascending))):names:fold(auto),(cloud.aws.lambda.throttlesByAccountIdFunctionNameRegion:filter(contains(functionname,\"-backend-api\")):splitBy(functionname):sum:sort(dimension(functionname,ascending))):names:fold(auto),(cloud.aws.lambda.durationByAccountIdFunctionNameRegion:filter(contains(functionname,\"-backend-api\")):splitBy(functionname):sort(dimension(functionname,ascending)):fold(max)):names:fold(auto),(cloud.aws.lambda.durationByAccountIdFunctionNameRegion:filter(contains(functionname,\"-backend-api\")):splitBy(functionname):sort(dimension(functionname,ascending)):fold(avg)):names:fold(auto),(cloud.aws.lambda.durationByAccountIdFunctionNameRegion:filter(contains(functionname,\"-backend-api\")):splitBy(functionname):sort(dimension(functionname,ascending)):fold(min)):names:fold(auto)"
+      ]
+    },
+    {
+      "name": "7a. DCMAW_APP_INFO_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_APP_INFO_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_APP_INFO_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "7b DCMAW_APP_INFO_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\",\"DCMAW_APP_INFO_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_APP_INFO_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "6. AppInfo-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_APP_INFO_STARTED\"), eq(\"messagecode\",\"DCMAW_APP_INFO_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_APP_INFO_STARTED),eq(messagecode,DCMAW_APP_INFO_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "FetchBiometricTokenV2-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1064,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED\"), eq(\"messagecode\",\"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "D"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED),eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1064,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.backend-api.logmessages.appInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_APP_INFO_STARTED\"))",
+          "rate": "NONE",
+          "enabled": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_FETCH_BIOMETRIC_TOKEN_V2_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1064,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.fetchBiometricTokenV2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_BIOMETRIC_TOKEN_V2_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "FinishBiometricSession2-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1292,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FINISH_BIOMETRIC_SESSION_STARTED\"), eq(\"messagecode\",\"DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_STARTED),eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_FINISH_BIOMETRIC_SESSION_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1292,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FINISH_BIOMETRIC_SESSION_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1292,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.finishBiometricSession2MessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FINISH_BIOMETRIC_SESSION_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "GetRedirect-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1520,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_GET_REDIRECT_STARTED\"), eq(\"messagecode\",\"DCMAW_GET_REDIRECT_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_GET_REDIRECT_STARTED),eq(messagecode,DCMAW_GET_REDIRECT_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_GET_REDIRECT_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1520,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_GET_REDIRECT_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_GET_REDIRECT_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_GET_REDIRECT_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1520,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_GET_REDIRECT_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.getRedirectMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_GET_REDIRECT_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "IssueAccessToken-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdMessageCodeRegionVersion:filter(not(or(eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_STARTED\"), eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED\")))):splitBy(\"messagecode\")",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "E"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdMessageCodeRegionVersion:filter(not(or(eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_STARTED),eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED)))):splitBy(messagecode)):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_ISSUE_ACCESS_TOKEN_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1748,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.issueAccessTokenMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_ISSUE_ACCESS_TOKEN_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "ResourceOwnerDocumentGroups-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2204,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED\"), eq(\"messagecode\",\"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED),eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2204,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2204,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.resourceOwnerDocumentGroupsMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_RESOURCE_OWNER_DOCUMENT_GROUPS_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "UserAbortCommand-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2432,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_USER_ABORT_COMMAND_STARTED\"), eq(\"messagecode\",\"DCMAW_USER_ABORT_COMMAND_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_USER_ABORT_COMMAND_STARTED),eq(messagecode,DCMAW_USER_ABORT_COMMAND_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_USER_ABORT_COMMAND_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2432,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_USER_ABORT_COMMAND_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_USER_ABORT_COMMAND_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_USER_ABORT_COMMAND_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2432,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_USER_ABORT_COMMAND_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.userAbortCommandMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_USER_ABORT_COMMAND_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "UserInfoFunction-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2660,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_STARTED\"), eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_STARTED),eq(messagecode,DCMAW_FETCH_USER_INFO_V2_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_FETCH_USER_INFO_V2_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2660,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_USER_INFO_V2_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_FETCH_USER_INFO_V2_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2660,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_FETCH_USER_INFO_V2_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "VerifyAuthorizeRequest-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED\"), eq(\"messagecode\",\"DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED),eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2888,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.verifyAuthorizeRequestMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_VERIFY_AUTHORIZE_REQUEST_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "WriteTxmaEvent-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3116,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_WRITE_TXMA_EVENT_STARTED\"), eq(\"messagecode\",\"DCMAW_WRITE_TXMA_EVENT_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_WRITE_TXMA_EVENT_STARTED),eq(messagecode,DCMAW_WRITE_TXMA_EVENT_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_WRITE_TXMA_EVENT_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3116,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_WRITE_TXMA_EVENT_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_WRITE_TXMA_EVENT_STARTED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_WRITE_TXMA_EVENT_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 3116,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_WRITE_TXMA_EVENT_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+            },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+          },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.writeTxmaEventMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_WRITE_TXMA_EVENT_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "DCMAW_OPENID_CONFIGURATION_STARTED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1976,
+        "left": 2280,
+        "width": 228,
+        "height": 228
+          },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_OPENID_CONFIGURATION_STARTED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_OPENID_CONFIGURATION_STARTED))):limit(100):names"
+      ]
+    },
+              {
+      "name": "DCMAW_OPENID_CONFIGURATION_COMPLETED",
+      "nameSize": "small",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1976,
+        "left": 2508,
+        "width": 228,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(\"messagecode\"):filter(eq(\"messagecode\", \"DCMAW_OPENID_CONFIGURATION_COMPLETED\"))",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+              }
+            ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": false,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": false
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_OPENID_CONFIGURATION_COMPLETED))):limit(100):names"
+      ]
+    },
+    {
+      "name": "OpenidConfiguration-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1976,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_OPENID_CONFIGURATION_STARTED\"), eq(\"messagecode\",\"DCMAW_OPENID_CONFIGURATION_COMPLETED\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_OPENID_CONFIGURATION_STARTED),eq(messagecode,DCMAW_OPENID_CONFIGURATION_COMPLETED)))):sum):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

## Ticket number:
[DCMAW-15694]

Change: the AWS custom metric dimensions have changed and therefore metrics are no longer available. This updates queries to use the latest dimension from AWS.

The diff is larger than I expected. From some spot checks, it looks like the majority of the diff is due to reordering of keys in the JSON. Process to produce this:

1. Clone dashboard
2. Export JSON to confirm the diff only contains metadata changes ✅ 
3. Click-ops changes to Dynatrace tiles - changes to a number of tiles to update the query used
4. Export JSON
5. Push changes using exported JSON

I've reviewed the click-opsed dashboard vs the original dashboard in Dynatrace - the untouched tiles look the same. The changed tiles are pulling through metrics using the latest metric dimensions.

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[DCMAW-15694]: https://govukverify.atlassian.net/browse/DCMAW-15694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ