### PR TITLE
AUT-4698: Add note to auth notification metrics dashboard around a potential delay in delivery receipts

### DIFF
--- a/dashboards/authentication/di-auth-notifications/di-auth-notifications.json.tpl
+++ b/dashboards/authentication/di-auth-notifications/di-auth-notifications.json.tpl
@@ -2214,12 +2214,12 @@
       "bounds": {
         "top": 1786,
         "left": 0,
-        "width": 950,
+        "width": 1140,
         "height": 190
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## SMS\n\nNote that there are two types of SMS metric:\n- **\"Send\" metrics**: This data is recorded each time we send a request to Notify to deliver an SMS message.\n- **\"Delivery receipt\" metrics**: These are provided by Notify and are not guaranteed. For international SMS' we only receive confirmations for approximately two-thirds of messages Notify attempted to send."
+      "markdown": "## SMS\n\nNote that there are two types of SMS metric:\n- **\"Send\" metrics**: This data is recorded each time we send a request to Notify to deliver an SMS message.\n- **\"Delivery receipt\" metrics**: These are provided by Notify and are not guaranteed. For international SMS' we only receive confirmations for approximately two-thirds of messages messages Notify attempted to send.\n\nAlso note that \"delivery metric\" statistics can sometimes be higher than the \"send\" statistics due to a delay in delivery receipts being issued by Notify."
     },
     {
       "name": "Markdown",
@@ -3095,14 +3095,14 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 2850,
+        "top": 2812,
         "left": 0,
         "width": 1216,
-        "height": 38
+        "height": 76
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "### SMS Delivery Metrics"
+      "markdown": "### SMS Delivery Metrics\n\nIf you see a \"delivery\" count which is higher than the \"send\" count (above), this may be due to delays in delivery receipts being issued by Notify."
     },
     {
       "name": "Domestic SMS' Delivered",


### PR DESCRIPTION
# Description:
Added some additional markdown to the authentication notification metrics dashboard related to potential delays in delivery receipts. No changes to metrics or data tiles.

Replaced the two variables in the template with prod values and manually imported the dashboard into Dynatrace (with a different "WIP"/"draft" dashboard name), rendered as expected - see screenshots on ticket linked below.

## Ticket number:
[AUT-4698](https://govukverify.atlassian.net/browse/AUT-4698?focusedCommentId=258837)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence - markdown additions only
- [x] I have tested this and added output to Jira Comment: https://govukverify.atlassian.net/browse/AUT-4698?focusedCommentId=258837 - see above, manually imported the changes into Dynatrace, working as expected
- [x] Documentation added: This PR adds this through the markdown changes


[AUT-4698]: https://govukverify.atlassian.net/browse/AUT-4698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ