### PR TITLE
AUT-4698: Make notification metrics dashboard shared

### DIFF
--- a/dashboards/authentication/di-auth-notifications/di-auth-notifications.json.tpl
+++ b/dashboards/authentication/di-auth-notifications/di-auth-notifications.json.tpl
@@ -7,7 +7,7 @@
   },
   "dashboardMetadata": {
     "name": "DI Authentication - Notification Metrics (${application_environment})",
-    "shared": false,
+    "shared": true,
     "owner": "authentication-developers@digital.cabinet-office.gov.uk",
     "tags": [
       "authentication"


### PR DESCRIPTION
# Description:

The notification metrics dashboard was previously not set to be shared

## Ticket number:
[AUT-4698](https://govukverify.atlassian.net/browse/AUT-4698?focusedCommentId=258837)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence - https://govukverify.atlassian.net/browse/AUT-4698?focusedCommentId=259144
- [x] I have tested this and added output to Jira Comment: - https://govukverify.atlassian.net/browse/AUT-4698?focusedCommentId=259144
- [x] Documentation added (link) Comment: N/A


[AUT-4698]: https://govukverify.atlassian.net/browse/AUT-4698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ