### PR TITLE
DCMAW-19129 Update STS metrics dashboard with minor fixes

### DIFF
--- a/dashboards/mobile-platform/mobile-platform.json
+++ b/dashboards/mobile-platform/mobile-platform.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.321.41.20250819-212053"
+    "clusterVersion": "1.334.44.20260317-201835"
   },
   "dashboardMetadata": {
     "name": "MOBILE - Mobile Platform",
@@ -52,7 +52,7 @@
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
-      "markdown": "## Max TPSPS \n\nIs it possible to get the max increase in transactions per second? \n\n"
+      "markdown": "## Max TPSPS \n\nIs it possible to get the max increase in transactions per second? \n\n"
     },
     {
       "name": "Markdown",
@@ -6358,156 +6358,6 @@
       ]
     },
     {
-      "name": "Lambda Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 4218,
-        "left": 0,
-        "width": 912,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "env",
-            "level",
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion\n:filter(\n  and(\n    or(\n        eq(\"aws.account.id\",\"671524980203\"),\n        eq(\"aws.account.id\",\"497065468681\"),\n        eq(\"aws.account.id\",\"921104553881\"),\n        eq(\"aws.account.id\",\"677276120913\"),\n        eq(\"aws.account.id\",\"605134434404\")\n      )\n    )\n)\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "env"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.txmaEventFunctionMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  and(\n    or(\n        eq(\"aws.account.id\",\"671524980203\"),\n        eq(\"aws.account.id\",\"497065468681\"),\n        eq(\"aws.account.id\",\"921104553881\"),\n        eq(\"aws.account.id\",\"677276120913\"),\n        eq(\"aws.account.id\",\"605134434404\")\n      )\n    )\n)\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "env",
-            "level",
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  and(\n    or(\n        eq(\"aws.account.id\",\"671524980203\"),\n        eq(\"aws.account.id\",\"497065468681\"),\n        eq(\"aws.account.id\",\"921104553881\"),\n        eq(\"aws.account.id\",\"677276120913\"),\n        eq(\"aws.account.id\",\"605134434404\")\n      )\n    )\n)\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_AREA",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_AREA",
-              "alias": "client-attestation"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_AREA",
-              "alias": "txma-event"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_AREA",
-              "alias": "app-check-auth"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(and(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.txmaEventFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names"
-      ]
-    },
-    {
       "name": "Lambda Invocations (sum)",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -7499,158 +7349,6 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.lambda.throttlesByAccountIdFunctionNameRegionResource:filter(and(or(eq(functionname,backend-api-enable-app-check-feature-flag),eq(functionname,backend-api-disable-app-check-feature-flag)),or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,functionname):sum:sort(dimension(env,descending),dimension(executedversion,ascending))):limit(100):names,(cloud.aws.lambda.throttlesByAccountIdFunctionNameRegionResource:filter(and(or(eq(functionname,backend-api-enable-app-check-feature-flag),eq(functionname,backend-api-disable-app-check-feature-flag)),or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env):sum:sort(dimension(env,descending),dimension(executedversion,ascending))):limit(100):names"
-      ]
-    },
-    {
-      "name": "Lambda ERROR Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 4446,
-        "left": 0,
-        "width": 912,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "env",
-            "level",
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion\n:filter(\n  or(\n    eq(\"aws.account.id\",\"671524980203\"),\n    eq(\"aws.account.id\",\"497065468681\"),\n    eq(\"aws.account.id\",\"921104553881\"),\n    eq(\"aws.account.id\",\"677276120913\"),\n    eq(\"aws.account.id\",\"605134434404\")\n  )\n)\n:filter(eq(\"level\",\"ERROR\"))\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "env",
-            "level",
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.txmaEventFunctionMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  or(\n    eq(\"aws.account.id\",\"671524980203\"),\n    eq(\"aws.account.id\",\"497065468681\"),\n    eq(\"aws.account.id\",\"921104553881\"),\n    eq(\"aws.account.id\",\"677276120913\"),\n    eq(\"aws.account.id\",\"605134434404\")\n  )\n)\n:filter(eq(\"level\",\"ERROR\"))\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "env",
-            "level",
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  or(\n    eq(\"aws.account.id\",\"671524980203\"),\n    eq(\"aws.account.id\",\"497065468681\"),\n    eq(\"aws.account.id\",\"921104553881\"),\n    eq(\"aws.account.id\",\"677276120913\"),\n    eq(\"aws.account.id\",\"605134434404\")\n  )\n)\n:filter(eq(\"level\",\"ERROR\"))\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_AREA",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "STACKED_AREA",
-              "alias": "client-attestation"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "STACKED_AREA",
-              "alias": "txma-event"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "RED",
-              "seriesType": "STACKED_AREA",
-              "alias": "app-check-auth"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "B",
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\"))):filter(eq(level,ERROR)):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.txmaEventFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\"))):filter(eq(level,ERROR)):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion:filter(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\"))):filter(eq(level,ERROR)):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names"
       ]
     },
     {
@@ -11143,16 +10841,13 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2166,
-        "left": 2812,
+        "top": 2280,
+        "left": 4370,
         "width": 304,
         "height": 304
       },
       "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Graph",
-      "queries": [],
-      "metricExpressions": []
+      "isAutoRefreshDisabled": false
     },
     {
       "name": "Mobile Platform Backend Api - TPS",
@@ -11259,8 +10954,8 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 2508,
-        "left": 4370,
+        "top": 4712,
+        "left": 1254,
         "width": 304,
         "height": 76
       },
@@ -11273,8 +10968,8 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 2508,
-        "left": 4066,
+        "top": 4712,
+        "left": 950,
         "width": 304,
         "height": 76
       },
@@ -11287,8 +10982,8 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 2508,
-        "left": 4712,
+        "top": 4712,
+        "left": 1596,
         "width": 304,
         "height": 76
       },
@@ -11301,10 +10996,10 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 2508,
-        "left": 3116,
-        "width": 912,
-        "height": 76
+        "top": 4674,
+        "left": 38,
+        "width": 874,
+        "height": 114
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -11315,8 +11010,8 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2584,
-        "left": 3116,
+        "top": 4788,
+        "left": 0,
         "width": 912,
         "height": 228
       },
@@ -11416,8 +11111,8 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2584,
-        "left": 4066,
+        "top": 4788,
+        "left": 950,
         "width": 304,
         "height": 228
       },
@@ -11524,8 +11219,8 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2584,
-        "left": 4370,
+        "top": 4788,
+        "left": 1254,
         "width": 304,
         "height": 228
       },
@@ -11656,8 +11351,8 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2584,
-        "left": 4712,
+        "top": 4788,
+        "left": 1596,
         "width": 304,
         "height": 228
       },
@@ -11756,6 +11451,310 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.lambda.concurrentExecutionsByAccountIdExecutedVersionFunctionNameRegionResource:filter(and(eq(functionname,backend-api-app-check-authorizer),or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,executedversion,functionname):max:sort(dimension(env,descending),dimension(functionname,ascending))):limit(100):names"
+      ]
+    },
+    {
+      "name": "Lambda Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4218,
+        "left": 0,
+        "width": 912,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "env",
+            "level",
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion\n:filter(\n  and(\n    or(\n        eq(\"aws.account.id\",\"671524980203\"),\n        eq(\"aws.account.id\",\"497065468681\"),\n        eq(\"aws.account.id\",\"921104553881\"),\n        eq(\"aws.account.id\",\"677276120913\"),\n        eq(\"aws.account.id\",\"605134434404\")\n      )\n    )\n)\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "env",
+            "level",
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.txmaEventMessageCodeByAccountIdLevelMessageCodeRegion:filter(\n  and(\n    or(\n        eq(\"aws.account.id\",\"671524980203\"),\n        eq(\"aws.account.id\",\"497065468681\"),\n        eq(\"aws.account.id\",\"921104553881\"),\n        eq(\"aws.account.id\",\"677276120913\"),\n        eq(\"aws.account.id\",\"605134434404\")\n      )\n    )\n)\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "env",
+            "level",
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  and(\n    or(\n        eq(\"aws.account.id\",\"671524980203\"),\n        eq(\"aws.account.id\",\"497065468681\"),\n        eq(\"aws.account.id\",\"921104553881\"),\n        eq(\"aws.account.id\",\"677276120913\"),\n        eq(\"aws.account.id\",\"605134434404\")\n      )\n    )\n)\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_AREA",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA",
+              "alias": "client-attestation"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA",
+              "alias": "txma-event"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_AREA",
+              "alias": "app-check-auth"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(and(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.txmaEventMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\")))):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names"
+      ]
+    },
+    {
+      "name": "Lambda ERROR Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 4446,
+        "left": 0,
+        "width": 912,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "env",
+            "level",
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion\n:filter(\n  or(\n    eq(\"aws.account.id\",\"671524980203\"),\n    eq(\"aws.account.id\",\"497065468681\"),\n    eq(\"aws.account.id\",\"921104553881\"),\n    eq(\"aws.account.id\",\"677276120913\"),\n    eq(\"aws.account.id\",\"605134434404\")\n  )\n)\n:filter(eq(\"level\",\"ERROR\"))\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "env",
+            "level",
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.txmaEventMessageCodeByAccountIdLevelMessageCodeRegion:filter(\n  or(\n    eq(\"aws.account.id\",\"671524980203\"),\n    eq(\"aws.account.id\",\"497065468681\"),\n    eq(\"aws.account.id\",\"921104553881\"),\n    eq(\"aws.account.id\",\"677276120913\"),\n    eq(\"aws.account.id\",\"605134434404\")\n  )\n)\n:filter(eq(\"level\",\"ERROR\"))\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "env",
+            "level",
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  or(\n    eq(\"aws.account.id\",\"671524980203\"),\n    eq(\"aws.account.id\",\"497065468681\"),\n    eq(\"aws.account.id\",\"921104553881\"),\n    eq(\"aws.account.id\",\"677276120913\"),\n    eq(\"aws.account.id\",\"605134434404\")\n  )\n)\n:filter(eq(\"level\",\"ERROR\"))\n:partition(\n  \"env\",\n  dimension(\"1-dev\"   ,eq(\"aws.account.id\",\"671524980203\")),\n  dimension(\"2-build\" ,eq(\"aws.account.id\",\"497065468681\")),\n  dimension(\"3-stage\" ,eq(\"aws.account.id\",\"921104553881\")),\n  dimension(\"4-int\"   ,eq(\"aws.account.id\",\"677276120913\")),\n  dimension(\"5-prod\"  ,eq(\"aws.account.id\",\"605134434404\")),\n  otherwise(\"UNKNOWN\")\n)\n:splitBy(env,\"level\",\"messagecode\")\n:sum\n:sort(dimension(\"env\",descending),dimension(\"level\",ascending),dimension(\"messagecode\",ascending))\n",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_AREA",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "STACKED_AREA",
+              "alias": "client-attestation"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "STACKED_AREA",
+              "alias": "txma-event"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "STACKED_AREA",
+              "alias": "app-check-auth"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.clientAttestationMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\"))):filter(eq(level,ERROR)):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.txmaEventMessageCodeByAccountIdLevelMessageCodeRegion:filter(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\"))):filter(eq(level,ERROR)):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names,(cloud.aws.backend-api.logmessages.appCheckAuthorizerMessageCodeByAccountIdLevelMessageCodeRegion:filter(or(eq(\"aws.account.id\",\"671524980203\"),eq(\"aws.account.id\",\"497065468681\"),eq(\"aws.account.id\",\"921104553881\"),eq(\"aws.account.id\",\"677276120913\"),eq(\"aws.account.id\",\"605134434404\"))):filter(eq(level,ERROR)):partition(env,dimension(\"1-dev\",eq(\"aws.account.id\",\"671524980203\")),dimension(\"2-build\",eq(\"aws.account.id\",\"497065468681\")),dimension(\"3-stage\",eq(\"aws.account.id\",\"921104553881\")),dimension(\"4-int\",eq(\"aws.account.id\",\"677276120913\")),dimension(\"5-prod\",eq(\"aws.account.id\",\"605134434404\")),otherwise(UNKNOWN)):splitBy(env,level,messagecode):sum:sort(dimension(env,descending),dimension(level,ascending),dimension(messagecode,ascending))):limit(100):names"
       ]
     }
   ]

--- a/dashboards/mobile-platform/sts/sts-metrics.json
+++ b/dashboards/mobile-platform/sts/sts-metrics.json
@@ -2044,154 +2044,6 @@
       ]
     },
     {
-      "name": "Number of Auth requests, Auth Codes issued, Initial Access Tokens Issued",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 760,
-        "left": 38,
-        "width": 798,
-        "height": 342
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "aws.account.id"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(\"messagecode\",\"STS_AUTHORIZE_STARTED\"))\n:splitBy(\"aws.account.id\")",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "aws.account.id"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(\"messagecode\",\"STS_REDIRECT_COMPLETED\"))\n:splitBy(\"aws.account.id\")",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "aws.account.id"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(\"messagecode\",\"STS_ACCESS_TOKEN_COMPLETED\"))\n:splitBy(\"aws.account.id\")",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {
-          "hideLegend": false
-        },
-        "rules": [
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "STS_AUTHORIZE_STARTED"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "STS_REDIRECT_COMPLETED"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "STS_ACCESS_TOKEN_COMPLETED"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "A",
-                "C",
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_AUTHORIZE_STARTED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_REDIRECT_COMPLETED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(messagecode,STS_ACCESS_TOKEN_COMPLETED)):splitBy(\"aws.account.id\")):limit(100):names"
-      ]
-    },
-    {
       "name": "Auth Code Exchange Rate",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -2500,6 +2352,154 @@
       "metricExpressions": [
         "resolution=Inf&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_STARTED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100):limit(100):names",
         "resolution=null&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_STARTED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100)"
+      ]
+    },
+    {
+      "name": "Number of Auth requests, Auth Codes issued, Initial Access Tokens Issued",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 760,
+        "left": 38,
+        "width": 798,
+        "height": 342
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(\"messagecode\",\"STS_AUTHORIZE_STARTED\"))\n:splitBy(\"aws.account.id\")",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(\"messagecode\",\"STS_REDIRECT_COMPLETED\"))\n:splitBy(\"aws.account.id\")",
+          "rate": "NONE",
+          "enabled": true
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(\"messagecode\",\"STS_ACCESS_TOKEN_COMPLETED\"))\n:splitBy(\"aws.account.id\")",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Auth requests"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Auth codes issued"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Access tokens issued"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "C",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_AUTHORIZE_STARTED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_REDIRECT_COMPLETED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(messagecode,STS_ACCESS_TOKEN_COMPLETED)):splitBy(\"aws.account.id\")):limit(100):names"
       ]
     }
   ]

--- a/dashboards/mobile-platform/sts/sts-metrics.json
+++ b/dashboards/mobile-platform/sts/sts-metrics.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.333.55.20260304-203337"
+    "clusterVersion": "1.333.57.20260305-233338"
   },
   "dashboardMetadata": {
     "name": "Mobile - STS Metrics",
@@ -982,14 +982,14 @@
       "markdown": "### Auth Code Exchange Rate (% of STS auth codes that are exchanged for an access token)"
     },
     {
-      "name": "Auth Code Exchange Rate",
+      "name": "Login Success Rate",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 2166,
-        "left": 646,
-        "width": 190,
-        "height": 304
+        "top": 0,
+        "left": 608,
+        "width": 228,
+        "height": 190
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -1320,14 +1320,14 @@
       ]
     },
     {
-      "name": "Login Success Rate",
+      "name": "Auth Code Exchange Rate",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 0,
+        "top": 2166,
         "left": 646,
         "width": 190,
-        "height": 190
+        "height": 304
       },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
@@ -1830,117 +1830,6 @@
       ]
     },
     {
-      "name": "Auth Code Exchange Rate",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2166,
-        "left": 38,
-        "width": 608,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "aws.account.id"
-          ],
-          "metricSelector": "100*cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(\n  and(\n    eq(\"messagecode\",\"STS_ACCESS_TOKEN_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n/\ncloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(\n  and(\n    eq(\"messagecode\",\"STS_AUTHORIZE_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Redirect Completion"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "B",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": [
-            "C:messagecode.name",
-            "C:aws.account.id.name",
-            "D:messagecode.name",
-            "D:aws.account.id.name"
-          ]
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(100*cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(and(eq(messagecode,STS_ACCESS_TOKEN_COMPLETED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")):limit(100):names"
-      ]
-    },
-    {
       "name": "Session Not Found",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -2395,36 +2284,49 @@
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
           "splitBy": [
-            "messagecode",
             "aws.account.id"
           ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(\"messagecode\",\"STS_ACCESS_TOKEN_COMPLETED\"))\n:splitBy(\"messagecode\",\"aws.account.id\")",
+          "metricSelector": "cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(\"messagecode\",\"STS_ACCESS_TOKEN_COMPLETED\"))\n:splitBy(\"aws.account.id\")",
           "rate": "NONE",
           "enabled": true
         }
       ],
       "visualConfig": {
         "type": "GRAPH_CHART",
-        "global": {},
+        "global": {
+          "hideLegend": false
+        },
         "rules": [
           {
             "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
             "properties": {
-              "color": "DEFAULT"
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "STS_AUTHORIZE_STARTED"
             },
             "seriesOverrides": []
           },
           {
             "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
             "properties": {
-              "color": "DEFAULT"
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "STS_REDIRECT_COMPLETED"
             },
             "seriesOverrides": []
           },
           {
             "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
             "properties": {
-              "color": "DEFAULT"
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "STS_ACCESS_TOKEN_COMPLETED"
             },
             "seriesOverrides": []
           }
@@ -2442,9 +2344,9 @@
               "max": "AUTO",
               "position": "LEFT",
               "queryIds": [
-                "B",
+                "A",
                 "C",
-                "A"
+                "B"
               ],
               "defaultAxis": true
             }
@@ -2486,7 +2388,118 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_AUTHORIZE_STARTED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_REDIRECT_COMPLETED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(messagecode,STS_ACCESS_TOKEN_COMPLETED)):splitBy(messagecode,\"aws.account.id\")):limit(100):names"
+        "resolution=null&(cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_AUTHORIZE_STARTED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:count:filter(eq(messagecode,STS_REDIRECT_COMPLETED)):splitBy(\"aws.account.id\")):limit(100):names,(cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionRequestType:count:filter(eq(messagecode,STS_ACCESS_TOKEN_COMPLETED)):splitBy(\"aws.account.id\")):limit(100):names"
+      ]
+    },
+    {
+      "name": "Auth Code Exchange Rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2166,
+        "left": 38,
+        "width": 608,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id"
+          ],
+          "metricSelector": "100*cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(\n  and(\n    eq(\"messagecode\",\"STS_ACCESS_TOKEN_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n/\ncloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(\n  and(\n    eq(\"messagecode\",\"STS_REDIRECT_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Redirect Completion"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:messagecode.name",
+            "C:aws.account.id.name",
+            "D:messagecode.name",
+            "D:aws.account.id.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(100*cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(and(eq(messagecode,STS_ACCESS_TOKEN_COMPLETED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(and(eq(messagecode,STS_REDIRECT_COMPLETED))):sum:splitBy(\"aws.account.id\")):limit(100):names"
       ]
     }
   ]

--- a/dashboards/mobile-platform/sts/sts-metrics.json
+++ b/dashboards/mobile-platform/sts/sts-metrics.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.333.57.20260305-233338"
+    "clusterVersion": "1.334.44.20260317-201835"
   },
   "dashboardMetadata": {
     "name": "Mobile - STS Metrics",
@@ -574,206 +574,6 @@
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
       "markdown": "### Return to STS from Orchestration success rate (% of redirections back to STS from Auth)"
-    },
-    {
-      "name": "Return to STS from Orchestration",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1482,
-        "left": 38,
-        "width": 608,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "aws.account.id"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(\n  and(\n    eq(\"messagecode\",\"STS_REDIRECT_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n/ \ncloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  and(\n    eq(\"messagecode\",\"STS_AUTHORIZE_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n*100",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "GRAPH_CHART",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Session Creation Rate"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": true,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "B",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": [
-            "C:messagecode.name",
-            "C:aws.account.id.name",
-            "D:messagecode.name",
-            "D:aws.account.id.name"
-          ]
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_COMPLETED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100):limit(100):names"
-      ]
-    },
-    {
-      "name": "Return to STS from Orchestration",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1482,
-        "left": 646,
-        "width": 190,
-        "height": 304
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Single value",
-      "queries": [
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "aws.account.id"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(\n  and(\n    eq(\"messagecode\",\"STS_REDIRECT_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n/ \ncloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  and(\n    eq(\"messagecode\",\"STS_AUTHORIZE_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n*100",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "SINGLE_VALUE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "A:",
-            "properties": {
-              "color": "DEFAULT"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "singleValueSettings": {
-          "showTrend": true,
-          "showSparkLine": false,
-          "linkTileColorToThreshold": true
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=Inf&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_COMPLETED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100):limit(100):names",
-        "resolution=null&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_COMPLETED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100)"
-      ]
     },
     {
       "name": "Authorize Success Rate",
@@ -2500,6 +2300,206 @@
       },
       "metricExpressions": [
         "resolution=null&(100*cloud.aws.backend-api.logmessages.tokenFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(and(eq(messagecode,STS_ACCESS_TOKEN_COMPLETED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegionVersion:filter(and(eq(messagecode,STS_REDIRECT_COMPLETED))):sum:splitBy(\"aws.account.id\")):limit(100):names"
+      ]
+    },
+    {
+      "name": "Return to STS from Orchestration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1482,
+        "left": 38,
+        "width": 608,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(\n  and(\n    eq(\"messagecode\",\"STS_REDIRECT_STARTED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n/ \ncloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  and(\n    eq(\"messagecode\",\"STS_AUTHORIZE_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n*100",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Session Creation Rate"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "B",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "C:messagecode.name",
+            "C:aws.account.id.name",
+            "D:messagecode.name",
+            "D:aws.account.id.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_STARTED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100):limit(100):names"
+      ]
+    },
+    {
+      "name": "Return to STS from Orchestration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1482,
+        "left": 646,
+        "width": 190,
+        "height": 304
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Single value",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "aws.account.id"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(\n  and(\n    eq(\"messagecode\",\"STS_REDIRECT_STARTED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n/ \ncloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion\n:filter(\n  and(\n    eq(\"messagecode\",\"STS_AUTHORIZE_COMPLETED\")\n  )\n)\n:sum:splitBy(\"aws.account.id\")\n*100",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": false,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=Inf&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_STARTED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100):limit(100):names",
+        "resolution=null&(cloud.aws.backend-api.logmessages.redirectFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_REDIRECT_STARTED))):sum:splitBy(\"aws.account.id\")/cloud.aws.backend-api.logmessages.authorizeFunctionMessageCodeByAccountIdLevelMessageCodeRegion:filter(and(eq(messagecode,STS_AUTHORIZE_COMPLETED))):sum:splitBy(\"aws.account.id\")*100)"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Update STS metrics dashboard with minor fixes:
- Update Number of Auth requests, Auth Codes issued, Initial Access Tokens Issued tile to use more descriptive legend labels - currently they are auto-generated. 
- Previously the single value tiles for "Login Success Rate" at the very top of the dashboard and "Auth Code Exchange Rate" were the wrong way round. These have been switched round.
- The "Auth Code Exchange Rate" line graph tile was showing the ratio of STS_ACCESS_TOKEN_COMPLETED to STS_AUTHORIZE_COMPLETED , when it should in fact be the ratio of STS_ACCESS_TOKEN_COMPLETED to STS_REDIRECT_COMPLETED. The query has been updated accordingly. 

Evidence on ticket.
**Updated evidence also on ticket**

## Ticket number:
[DCMAW-19129](https://govukverify.atlassian.net/browse/DCMAW-19129)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [n/a] Documentation added (link) Comment:


[DCMAW-19129]: https://govukverify.atlassian.net/browse/DCMAW-19129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ