### PR TITLE
FPAD-7509: Updated FPAD TICF dashboard to include P95/P99 metrics

### DIFF
--- a/documents/fraud/ticf-cri/ticf-cri-infrastructure.json
+++ b/documents/fraud/ticf-cri/ticf-cri-infrastructure.json
@@ -60,10 +60,7 @@
       "type": "markdown",
       "content": "## Fraud TICF CRI Dashboard\n\nThis dashboard displays metrics for the TICF-CRI system Staging, Integration and Production environment. For further information on TICF CRI see [here](https://govukverify.atlassian.net/wiki/spaces/FPAD/pages/3765012906/Technical+solution)."
     },
-    "1": {
-      "type": "markdown",
-      "content": "## Gateway and WAF Metrics"
-    },
+    "1": { "type": "markdown", "content": "## Gateway and WAF Metrics" },
     "2": {
       "title": "Gateway Request Latency",
       "type": "data",
@@ -72,29 +69,17 @@
       "visualizationSettings": {
         "chartSettings": {
           "truncationMode": "middle",
-          "leftYAxisSettings": {
-            "label": "Latency",
-            "isLabelVisible": true
-          },
-          "rightYAxisSettings": {
-            "label": "Latency",
-            "isLabelVisible": true
-          },
+          "leftYAxisSettings": { "label": "Latency", "isLabelVisible": true },
+          "rightYAxisSettings": { "label": "Latency", "isLabelVisible": true },
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "Avg Latency",
-              "Max Latency",
-              "Min Latency"
-            ],
+            "leftAxisValues": ["Avg Latency", "Max Latency", "Min Latency"],
             "timestamp": "timeframe"
           },
           "gapPolicy": "connect"
         },
-        "legend": {
-          "ratio": 27
-        },
+        "legend": { "ratio": 27 },
         "autoSelectVisualization": false,
         "thresholds": [
           {
@@ -102,24 +87,9 @@
             "title": "",
             "field": "countByAccountIdApiNameRegionStage",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
@@ -174,9 +144,7 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       }
     },
     "3": {
@@ -187,61 +155,32 @@
       "visualizationSettings": {
         "chartSettings": {
           "truncationMode": "middle",
-          "leftYAxisSettings": {
-            "label": "Errors",
-            "isLabelVisible": true
-          },
+          "leftYAxisSettings": { "label": "Errors", "isLabelVisible": true },
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "Errors4xx",
-              "Errors5xx"
-            ],
+            "leftAxisValues": ["Errors4xx", "Errors5xx"],
             "timestamp": "timeframe"
           },
-          "gapPolicy": {
-            "threshold": "1h"
-          }
+          "gapPolicy": { "threshold": "1h" }
         },
-        "legend": {
-          "ratio": 26
-        },
+        "legend": { "ratio": 26 },
         "thresholds": [
           {
             "id": "0",
             "title": "",
             "field": "4xxErrorByAccountIdApiNameRegionStage",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
         ],
         "unitsOverrides": [],
         "dataMapping": {
-          "displayedFields": [
-            "apiname",
-            "Errors4xx",
-            "Errors5xx"
-          ]
+          "displayedFields": ["apiname", "Errors4xx", "Errors5xx"]
         }
       },
       "querySettings": {
@@ -253,9 +192,7 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       }
     },
     "4": {
@@ -265,6 +202,18 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
+          "hiddenColumns": [
+            ["timeframe"],
+            ["interval"],
+            ["countByAccountIdApiNameRegion"],
+            ["latencyByAccountIdApiNameRegion"]
+          ],
+          "columnWidths": {
+            "[\"apiname\"]": 261.6579895019531,
+            "[\"countByAccountIdApiNameRegion\"]": 112.14236450195312,
+            "[\"API Name\"]": 336.9600830078125,
+            "[\"Count\"]": 153.50868225097656
+          },
           "columnTypeOverrides": [
             {
               "fields": [
@@ -272,29 +221,10 @@
                 "latencyByAccountIdApiNameRegion"
               ],
               "value": "sparkline",
-              "id": 1741626519288
+              "id": 1741626519288,
+              "disableRemoval": false
             }
-          ],
-          "hiddenColumns": [
-            [
-              "timeframe"
-            ],
-            [
-              "interval"
-            ],
-            [
-              "countByAccountIdApiNameRegion"
-            ],
-            [
-              "latencyByAccountIdApiNameRegion"
-            ]
-          ],
-          "columnWidths": {
-            "[\"apiname\"]": 261.6579895019531,
-            "[\"countByAccountIdApiNameRegion\"]": 112.14236450195312,
-            "[\"API Name\"]": 336.9600830078125,
-            "[\"Count\"]": 153.50868225097656
-          }
+          ]
         },
         "thresholds": [
           {
@@ -302,24 +232,9 @@
             "title": "",
             "field": "countByAccountIdApiNameRegion",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
@@ -356,9 +271,7 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       }
     },
     "5": {
@@ -368,25 +281,18 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
+          "hiddenColumns": [
+            ["timeframe"],
+            ["interval"],
+            ["4xxErrorByAccountIdApiNameRegionStage"]
+          ],
           "columnTypeOverrides": [
             {
-              "fields": [
-                "4xxErrorByAccountIdApiNameRegionStage"
-              ],
+              "fields": ["4xxErrorByAccountIdApiNameRegionStage"],
               "value": "sparkline",
-              "id": 1741626519495
+              "id": 1741626519495,
+              "disableRemoval": false
             }
-          ],
-          "hiddenColumns": [
-            [
-              "timeframe"
-            ],
-            [
-              "interval"
-            ],
-            [
-              "4xxErrorByAccountIdApiNameRegionStage"
-            ]
           ]
         },
         "thresholds": [
@@ -395,24 +301,9 @@
             "title": "",
             "field": "4xxErrorByAccountIdApiNameRegionStage",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
@@ -439,9 +330,7 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       }
     },
     "6": {
@@ -451,25 +340,18 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
+          "hiddenColumns": [
+            ["timeframe"],
+            ["interval"],
+            ["5xxErrorByAccountIdApiNameRegionStage"]
+          ],
           "columnTypeOverrides": [
             {
-              "fields": [
-                "5xxErrorByAccountIdApiNameRegionStage"
-              ],
+              "fields": ["5xxErrorByAccountIdApiNameRegionStage"],
               "value": "sparkline",
-              "id": 1741626519500
+              "id": 1741626519500,
+              "disableRemoval": false
             }
-          ],
-          "hiddenColumns": [
-            [
-              "timeframe"
-            ],
-            [
-              "interval"
-            ],
-            [
-              "5xxErrorByAccountIdApiNameRegionStage"
-            ]
           ]
         },
         "thresholds": [
@@ -478,24 +360,9 @@
             "title": "",
             "field": "5xxErrorByAccountIdApiNameRegionStage",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
@@ -522,9 +389,7 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       }
     },
     "7": {
@@ -534,28 +399,11 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
-          "columnTypeOverrides": [
-            {
-              "fields": [
-                "blockedRequestsByAccountIdRegionRuleWebACL"
-              ],
-              "value": "sparkline",
-              "id": 1741626519436
-            }
-          ],
           "hiddenColumns": [
-            [
-              "timeframe"
-            ],
-            [
-              "interval"
-            ],
-            [
-              "region"
-            ],
-            [
-              "blockedRequestsByAccountIdRegionRuleWebACL"
-            ]
+            ["timeframe"],
+            ["interval"],
+            ["region"],
+            ["blockedRequestsByAccountIdRegionRuleWebACL"]
           ],
           "rowDensity": "default",
           "selectedColumnForRowThreshold": "blockedRequestsByAccountIdRegionRuleWebACL",
@@ -564,7 +412,15 @@
             "[\"Account\"]": 123.42535400390625,
             "[\"Region\"]": 107.5763931274414,
             "[\"Web ACL\"]": 503.3090515136719
-          }
+          },
+          "columnTypeOverrides": [
+            {
+              "fields": ["blockedRequestsByAccountIdRegionRuleWebACL"],
+              "value": "sparkline",
+              "id": 1741626519436,
+              "disableRemoval": false
+            }
+          ]
         },
         "autoSelectVisualization": false,
         "thresholds": [
@@ -573,24 +429,9 @@
             "title": "",
             "field": "blockedRequestsByAccountIdRegionRuleWebACL",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
@@ -628,15 +469,10 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       }
     },
-    "8": {
-      "type": "markdown",
-      "content": "## Lambda Metrics"
-    },
+    "8": { "type": "markdown", "content": "## Lambda Metrics" },
     "25": {
       "title": "Invocations",
       "type": "code",
@@ -648,19 +484,13 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "invocationsByAccountIdFunctionNameRegion"
-            ],
+            "leftAxisValues": ["invocationsByAccountIdFunctionNameRegion"],
             "timestamp": "timeframe"
           }
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "26": {
@@ -671,26 +501,18 @@
       "visualizationSettings": {
         "chartSettings": {
           "truncationMode": "middle",
-          "legend": {
-            "hidden": true
-          },
+          "legend": { "hidden": true },
           "categoryOverrides": {},
           "categoricalBarChartSettings": {
             "categoryAxisLabel": "functionname",
             "isCategoryLabelVisible": false,
-            "categoryAxis": [
-              "functionname"
-            ],
-            "valueAxis": [
-              "invocationsSum"
-            ],
+            "categoryAxis": ["functionname"],
+            "valueAxis": ["invocationsSum"],
             "valueAxisLabel": "invocationsSum",
             "isValueLabelVisible": false
           }
         },
-        "legend": {
-          "ratio": 15
-        },
+        "legend": { "ratio": 15 },
         "autoSelectVisualization": false,
         "thresholds": [],
         "unitsOverrides": [
@@ -718,9 +540,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "durationByAccountIdFunctionNameRegion"
-            ],
+            "leftAxisValues": ["durationByAccountIdFunctionNameRegion"],
             "timestamp": "timeframe"
           }
         },
@@ -738,11 +558,7 @@
             "added": 1740153156962
           }
         ],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "28": {
@@ -755,9 +571,7 @@
           "truncationMode": "middle",
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
-          "tooltip": {
-            "variant": "shared"
-          },
+          "tooltip": { "variant": "shared" },
           "fieldMapping": {
             "leftAxisValues": [
               "concurrentExecutionsByAccountIdFunctionNameRegion"
@@ -767,11 +581,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "29": {
@@ -785,9 +595,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "errorRate"
-            ],
+            "leftAxisValues": ["errorRate"],
             "timestamp": "timeframe"
           },
           "gapPolicy": "connect"
@@ -806,11 +614,7 @@
             "added": 1740155455179
           }
         ],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "30": {
@@ -824,19 +628,13 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "errorsByAccountIdFunctionNameRegion"
-            ],
+            "leftAxisValues": ["errorsByAccountIdFunctionNameRegion"],
             "timestamp": "timeframe"
           }
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "31": {
@@ -850,9 +648,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "throttleCount"
-            ],
+            "leftAxisValues": ["throttleCount"],
             "timestamp": "timeframe"
           }
         },
@@ -891,11 +687,7 @@
             ]
           }
         ],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "32": {
@@ -906,31 +698,17 @@
       "visualizationSettings": {
         "chartSettings": {
           "truncationMode": "middle",
-          "legend": {
-            "position": "bottom"
-          },
-          "leftYAxisSettings": {
-            "label": "Count",
-            "isLabelVisible": true
-          },
+          "legend": { "position": "bottom" },
+          "leftYAxisSettings": { "label": "Count", "isLabelVisible": true },
           "rightYAxisSettings": {
             "label": "Response Time",
             "isLabelVisible": true
           },
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
-          "hiddenLegendFields": [
-            "dt.entity.service",
-            "metricName",
-            "interval"
-          ],
+          "hiddenLegendFields": ["dt.entity.service", "metricName", "interval"],
           "fieldMapping": {
-            "leftAxisValues": [
-              "Count",
-              "p50",
-              "p90",
-              "p99"
-            ],
+            "leftAxisValues": ["Count", "p50", "p90", "p99"],
             "timestamp": "timeframe"
           },
           "gapPolicy": "connect"
@@ -993,23 +771,16 @@
             "label": "Request Count",
             "isLabelVisible": true
           },
-          "rightYAxisSettings": {
-            "label": "Latency",
-            "isLabelVisible": true
-          },
+          "rightYAxisSettings": { "label": "Latency", "isLabelVisible": true },
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "Count"
-            ],
+            "leftAxisValues": ["Count"],
             "timestamp": "timeframe"
           },
           "gapPolicy": "connect"
         },
-        "legend": {
-          "ratio": 26
-        },
+        "legend": { "ratio": 26 },
         "autoSelectVisualization": false,
         "thresholds": [
           {
@@ -1058,11 +829,7 @@
             "added": 1740138132831
           }
         ],
-        "dataMapping": {
-          "displayedFields": [
-            "apiname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["apiname"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1096,21 +863,13 @@
           },
           "analyzerHints": {
             "dt.statistics.ui.anomaly_detection.StaticThresholdAnomalyDetectionAnalyzer": {
-              "unit": {
-                "unitCategory": "unspecified",
-                "baseUnit": "count"
-              }
+              "unit": { "unitCategory": "unspecified", "baseUnit": "count" }
             }
           }
         },
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
-      "segments": {
-        "tileSegments": [],
-        "tileSegmentsEnabled": false
-      }
+      "segments": { "tileSegments": [], "tileSegmentsEnabled": false }
     },
     "37": {
       "title": "Claimed Account Concurrency for $SelectedAWSAccount",
@@ -1120,9 +879,7 @@
       "visualizationSettings": {
         "chartSettings": {
           "truncationMode": "middle",
-          "legend": {
-            "hidden": true
-          },
+          "legend": { "hidden": true },
           "leftYAxisSettings": {
             "label": "ConcurrentExecutions",
             "isLabelVisible": true
@@ -1187,9 +944,7 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       }
     },
     "39": {
@@ -1202,9 +957,7 @@
           "truncationMode": "middle",
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
-          "hiddenLegendFields": [
-            "interval"
-          ],
+          "hiddenLegendFields": ["interval"],
           "fieldMapping": {
             "leftAxisValues": [
               "concurrentExecutionsByAccountIdFunctionNameRegion"
@@ -1227,9 +980,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "asyncEventAge"
-            ],
+            "leftAxisValues": ["asyncEventAge"],
             "timestamp": "timeframe"
           }
         },
@@ -1247,11 +998,7 @@
             "added": 1741623406425
           }
         ],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "41": {
@@ -1265,19 +1012,13 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "asyncEventsReceived"
-            ],
+            "leftAxisValues": ["asyncEventsReceived"],
             "timestamp": "timeframe"
           }
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "42": {
@@ -1291,9 +1032,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "iteratorAge"
-            ],
+            "leftAxisValues": ["iteratorAge"],
             "timestamp": "timeframe"
           }
         },
@@ -1311,11 +1050,7 @@
             "added": 1741623770672
           }
         ],
-        "dataMapping": {
-          "displayedFields": [
-            "functionname"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["functionname"] }
       }
     },
     "50": {
@@ -1328,26 +1063,14 @@
           "truncationMode": "middle",
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
-          "hiddenLegendFields": [
-            "interval",
-            "errorCount",
-            "errorsByAccountIdFunctionNameRegion"
-          ],
-          "fieldMapping": {
-            "leftAxisValues": [
-              "a"
-            ],
-            "timestamp": "timeframe"
-          }
+          "fieldMapping": { "leftAxisValues": ["a"], "timestamp": "timeframe" }
         },
         "autoSelectVisualization": false,
-        "thresholds": []
+        "thresholds": [],
+        "dataMapping": { "displayedFields": ["statuscode", "service"] }
       }
     },
-    "51": {
-      "type": "markdown",
-      "content": "## Dynamo DB Metrics"
-    },
+    "51": { "type": "markdown", "content": "## Dynamo DB Metrics" },
     "52": {
       "title": "Throttled Requests",
       "type": "data",
@@ -1359,9 +1082,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "throttledRequests"
-            ],
+            "leftAxisValues": ["throttledRequests"],
             "timestamp": "timeframe"
           }
         },
@@ -1372,47 +1093,15 @@
             "title": "",
             "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
         ],
         "unitsOverrides": [],
-        "dataMapping": {
-          "displayedFields": [
-            "tablename"
-          ]
-        }
-      },
-      "davis": {
-        "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
-      },
-      "timeframe": {
-        "tileTimeframeEnabled": true,
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        }
+        "dataMapping": { "displayedFields": ["tablename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1420,6 +1109,14 @@
         "maxResultMegaBytes": 1,
         "defaultSamplingRatio": 10,
         "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      },
+      "timeframe": {
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
+        "tileTimeframeEnabled": true
       }
     },
     "53": {
@@ -1432,16 +1129,8 @@
           "truncationMode": "middle",
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
-          "hiddenLegendFields": [
-            "successfulRequestLatencyByAccountIdOperationRegionTableName",
-            "successfulRequestLatencyByAccountIdOperationRegionTableName.0",
-            "successfulRequestLatencyByAccountIdOperationRegionTableName.1",
-            "interval"
-          ],
           "fieldMapping": {
-            "leftAxisValues": [
-              "writeThrottleEvents"
-            ],
+            "leftAxisValues": ["writeThrottleEvents"],
             "timestamp": "timeframe"
           }
         },
@@ -1452,29 +1141,15 @@
             "title": "",
             "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
         ],
-        "unitsOverrides": []
+        "unitsOverrides": [],
+        "dataMapping": { "displayedFields": ["tablename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1485,16 +1160,11 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframeEnabled": true,
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        }
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
+        "tileTimeframeEnabled": true
       }
     },
     "54": {
@@ -1508,9 +1178,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "consumedReadCapacity"
-            ],
+            "leftAxisValues": ["consumedReadCapacity"],
             "timestamp": "timeframe"
           }
         },
@@ -1521,47 +1189,15 @@
             "title": "",
             "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
         ],
         "unitsOverrides": [],
-        "dataMapping": {
-          "displayedFields": [
-            "tablename"
-          ]
-        }
-      },
-      "davis": {
-        "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
-      },
-      "timeframe": {
-        "tileTimeframeEnabled": true,
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        }
+        "dataMapping": { "displayedFields": ["tablename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1569,6 +1205,14 @@
         "maxResultMegaBytes": 1,
         "defaultSamplingRatio": 10,
         "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      },
+      "timeframe": {
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
+        "tileTimeframeEnabled": true
       }
     },
     "55": {
@@ -1582,9 +1226,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "consumedReadCapacity"
-            ],
+            "leftAxisValues": ["consumedReadCapacity"],
             "timestamp": "timeframe"
           }
         },
@@ -1595,47 +1237,15 @@
             "title": "",
             "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
         ],
         "unitsOverrides": [],
-        "dataMapping": {
-          "displayedFields": [
-            "tablename"
-          ]
-        }
-      },
-      "davis": {
-        "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
-      },
-      "timeframe": {
-        "tileTimeframeEnabled": true,
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        }
+        "dataMapping": { "displayedFields": ["tablename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1643,6 +1253,14 @@
         "maxResultMegaBytes": 1,
         "defaultSamplingRatio": 10,
         "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      },
+      "timeframe": {
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
+        "tileTimeframeEnabled": true
       }
     },
     "56": {
@@ -1656,9 +1274,7 @@
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": {
-            "leftAxisValues": [
-              "requestLatency"
-            ],
+            "leftAxisValues": ["requestLatency"],
             "timestamp": "timeframe"
           }
         },
@@ -1669,48 +1285,15 @@
             "title": "",
             "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
             "rules": [
-              {
-                "id": "0",
-                "label": "",
-                "comparator": "≥",
-                "color": "#7dc540"
-              },
-              {
-                "id": "1",
-                "label": "",
-                "comparator": "≥",
-                "color": "#f5d30f"
-              },
-              {
-                "id": "2",
-                "label": "",
-                "comparator": "≥",
-                "color": "#dc172a"
-              }
+              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
+              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
+              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
             ],
             "isEnabled": true
           }
         ],
         "unitsOverrides": [],
-        "dataMapping": {
-          "displayedFields": [
-            "tablename",
-            "operation"
-          ]
-        }
-      },
-      "davis": {
-        "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
-      },
-      "timeframe": {
-        "tileTimeframeEnabled": true,
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        }
+        "dataMapping": { "displayedFields": ["tablename", "operation"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1718,12 +1301,17 @@
         "maxResultMegaBytes": 1,
         "defaultSamplingRatio": 10,
         "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      },
+      "timeframe": {
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
+        "tileTimeframeEnabled": true
       }
     },
-    "57": {
-      "type": "markdown",
-      "content": "## SQS Metrics"
-    },
+    "57": { "type": "markdown", "content": "## SQS Metrics" },
     "62": {
       "title": "Messages Sent - SQS",
       "description": "",
@@ -1744,9 +1332,7 @@
               "seriesId": [
                 "count(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion)"
               ],
-              "override": {
-                "color": "#b3007d"
-              }
+              "override": { "color": "#b3007d" }
             }
           ],
           "fieldMapping": {
@@ -1758,11 +1344,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1773,21 +1355,13 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       },
-      "segments": {
-        "tileSegments": [],
-        "tileSegmentsEnabled": false
-      }
+      "segments": { "tileSegments": [], "tileSegmentsEnabled": false }
     },
     "63": {
       "title": "Messages Received - SQS",
@@ -1812,11 +1386,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1827,15 +1397,10 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
@@ -1862,11 +1427,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1877,15 +1438,10 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
@@ -1912,11 +1468,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1927,15 +1479,10 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
@@ -1945,12 +1492,8 @@
       "query": "timeseries approximateAgeOfOldestMessageByAccountIdQueueNameRegion=avg(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion),by:{queuename}, filter: { aws.account.id == $SelectedAWSAccount AND NOT(contains( queuename, \"DeadLetter\"))}",
       "visualization": "lineChart",
       "visualizationSettings": {
-        "chartSettings": {
-          "xAxisScaling": "analyzedTimeframe"
-        },
-        "legend": {
-          "ratio": 23
-        },
+        "chartSettings": { "xAxisScaling": "analyzedTimeframe" },
+        "legend": { "ratio": 23 },
         "autoSelectVisualization": false,
         "thresholds": [
           {
@@ -1990,22 +1533,14 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-2h",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-2h", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
-    "68": {
-      "type": "markdown",
-      "content": "## DLQ Metrics\n"
-    },
+    "68": { "type": "markdown", "content": "## DLQ Metrics\n" },
     "69": {
       "title": "Messages Sent - DLQ",
       "description": "",
@@ -2026,9 +1561,7 @@
               "seriesId": [
                 "count(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion)"
               ],
-              "override": {
-                "color": "#b3007d"
-              }
+              "override": { "color": "#b3007d" }
             }
           ],
           "fieldMapping": {
@@ -2040,11 +1573,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -2055,21 +1584,13 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       },
-      "segments": {
-        "tileSegments": [],
-        "tileSegmentsEnabled": false
-      }
+      "segments": { "tileSegments": [], "tileSegmentsEnabled": false }
     },
     "70": {
       "title": "Messages Received - DLQ",
@@ -2094,11 +1615,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -2109,15 +1626,10 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
@@ -2144,11 +1656,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -2159,15 +1667,10 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
@@ -2194,11 +1697,7 @@
         },
         "autoSelectVisualization": false,
         "thresholds": [],
-        "dataMapping": {
-          "displayedFields": [
-            "queuename"
-          ]
-        }
+        "dataMapping": { "displayedFields": ["queuename"] }
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -2209,15 +1708,10 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-365d",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
@@ -2227,12 +1721,8 @@
       "query": "timeseries approximateAgeOfOldestMessageByAccountIdQueueNameRegion=avg(cloud.aws.sqs.approximateAgeOfOldestMessageByAccountIdQueueNameRegion),by:{queuename}, filter: { aws.account.id == $SelectedAWSAccount AND contains( queuename, \"DeadLetter\")}",
       "visualization": "lineChart",
       "visualizationSettings": {
-        "chartSettings": {
-          "xAxisScaling": "analyzedTimeframe"
-        },
-        "legend": {
-          "ratio": 23
-        },
+        "chartSettings": { "xAxisScaling": "analyzedTimeframe" },
+        "legend": { "ratio": 23 },
         "autoSelectVisualization": false,
         "thresholds": [
           {
@@ -2272,361 +1762,511 @@
       },
       "davis": {
         "enabled": false,
-        "davisVisualization": {
-          "isAvailable": true
-        }
+        "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": {
-          "from": "now()-2h",
-          "to": "now()"
-        },
+        "tileTimeframe": { "from": "now()-2h", "to": "now()" },
         "tileTimeframeEnabled": false
       }
     },
     "74": {
-      "type": "code",
       "title": "Successful SIRA Response Count",
-      "input": "import { queryExecutionClient } from '@dynatrace-sdk/client-query';\n\nexport default async function () {\n  const timeout = 60;\n  let query;\n  let env:string = $EnvironmentName;\n  let awsAccount:string = $SelectedAWSAccount\n\n  query =`timeseries { tally = sum(\\`cloud.aws.${env}-ticf-cri.siraSuccessResponseCountByAccountIdRegionservice\\`), interval: 1m } | fieldsRename \\`Successful SIRA Responses\\` = tally`;\n  \n  const response = await queryExecutionClient.queryExecute({ body: { query, requestTimeoutMilliseconds: timeout * 1000, fetchTimeoutSeconds: timeout } });\n  return response.result;\n}",
-      "visualizationSettings": {
-        "autoSelectVisualization": false
-      },
-      "visualization": "lineChart",
-      "description": ""
-    },
-    "75": {
-      "type": "markdown",
-      "content": "## Custom Alarm Metrics"
-    },
-    "76": {
+      "description": "",
       "type": "code",
+      "input": "import { queryExecutionClient } from '@dynatrace-sdk/client-query';\n\nexport default async function () {\n  const timeout = 60;\n  let query;\n  let env:string = $EnvironmentName;\n  let awsAccount:string = $SelectedAWSAccount\n\n  query =`timeseries { tally = sum(\\`cloud.aws.${env}-ticf-cri.siraSuccessResponseCountByAccountIdRegionservice\\`), interval: 1m } | fieldsRename \\`Successful SIRA Responses\\` = tally`;\n  \n  const response = await queryExecutionClient.queryExecute({ body: { query, requestTimeoutMilliseconds: timeout * 1000, fetchTimeoutSeconds: timeout } });\n  return response.result;\n}",
+      "visualization": "lineChart",
+      "visualizationSettings": { "autoSelectVisualization": false }
+    },
+    "75": { "type": "markdown", "content": "## Custom Alarm Metrics" },
+    "76": {
       "title": "Lambda Error Processing Count",
+      "type": "code",
       "input": "import { queryExecutionClient } from '@dynatrace-sdk/client-query';\n\nexport default async function () {\n  const timeout = 60;\n  let query;\n  let env:string = $EnvironmentName;\n\n  query =`timeseries { tally = count(\\`cloud.aws.${env}-ticf-cri.errorProcessingByAccountIdRegionservice\\`) }, filter: { aws.account.id == \"${$SelectedAWSAccount}\" } | fieldsRename \\`Lambda Error Processing\\` = tally`;\n\n  const response = await queryExecutionClient.queryExecute({ body: { query, requestTimeoutMilliseconds: timeout * 1000, fetchTimeoutSeconds: timeout } });\n  return response.result;\n}",
-      "visualizationSettings": {
-        "autoSelectVisualization": false
-      },
-      "visualization": "lineChart"
+      "visualization": "lineChart",
+      "visualizationSettings": { "autoSelectVisualization": false }
     },
     "77": {
-      "type": "code",
       "title": "Number of TxMA Events Received",
+      "type": "code",
       "input": "import { queryExecutionClient } from '@dynatrace-sdk/client-query';\n\nexport default async function () {\n  const timeout = 60;\n  let query;\n  let env:string = $EnvironmentName;\n\n  query =`timeseries { tally = sum(\\`cloud.aws.${env}-ticf-cri.txmaSelfServiceReceiveCountByAccountIdRegionservice\\`), interval: 1m }, filter: { aws.account.id == \"${$SelectedAWSAccount}\" } | fieldsRename \\`TxMA Self Service Events Received\\` = tally`;\n\n  const response = await queryExecutionClient.queryExecute({ body: { query, requestTimeoutMilliseconds: timeout * 1000, fetchTimeoutSeconds: timeout } });\n  return response.result;\n}",
-      "visualizationSettings": {
-        "autoSelectVisualization": false
-      },
-      "visualization": "lineChart"
+      "visualization": "lineChart",
+      "visualizationSettings": { "autoSelectVisualization": false }
     },
     "78": {
-      "type": "code",
       "title": "Number of TxMA Events Sent",
+      "type": "code",
       "input": "import { queryExecutionClient } from '@dynatrace-sdk/client-query';\n\nexport default async function () {\n  const timeout = 60;\n  let query;\n  let env:string = $EnvironmentName;\n\n  query =`timeseries { tally = sum(\\`cloud.aws.${env}-ticf-cri.txmaEventSentCountByAccountIdRegionservice\\`), interval: 1m }, filter: { aws.account.id == \"${$SelectedAWSAccount}\" } | fieldsRename \\`TxMA Events Sent\\` = tally`;\n\n  const response = await queryExecutionClient.queryExecute({ body: { query, requestTimeoutMilliseconds: timeout * 1000, fetchTimeoutSeconds: timeout } });\n  return response.result;\n}",
+      "visualization": "lineChart",
+      "visualizationSettings": { "autoSelectVisualization": false }
+    },
+    "79": {
+      "title": "Gateway Risk Assessment Availability",
+      "description": "A percentage of success responses to 5xx responses. 4xx errors are not included.",
+      "type": "data",
+      "query": "timeseries { `5xxErrorByAccountIdApiNameRegionStage` = sum(cloud.aws.apigateway.5xxErrorByAccountIdApiNameRegionStage), countByAccountIdApiNameRegion = sum(cloud.aws.apigateway.countByAccountIdApiNameRegion)}, \nby: { apiname },\nfilter: { aws.account.id == $SelectedAWSAccount }\n| filter apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsAdd ErrorCount = arraySum(`5xxErrorByAccountIdApiNameRegionStage`)\n| fieldsAdd TotalCount = arraySum(`countByAccountIdApiNameRegion`)\n| summarize\n    ErrorCount = sum(ErrorCount),\n    TotalCount = sum(TotalCount)\n| fieldsAdd `Success %` = ((TotalCount - ErrorCount) / TotalCount) * 100.0\n| fields `Success %`",
+      "visualization": "gauge",
       "visualizationSettings": {
+        "unitsOverrides": [
+          {
+            "identifier": "Success %",
+            "unitCategory": "percentage",
+            "baseUnit": "percent",
+            "displayUnit": null,
+            "decimals": 3,
+            "suffix": "",
+            "delimiter": true,
+            "added": 1773144594244
+          }
+        ],
+        "colorModeType": {
+          "color": "#DC172A",
+          "customNumericColors": [
+            {
+              "id": 2161353.200000018,
+              "value": 100,
+              "color": "#7DC540",
+              "comparator": "≥"
+            },
+            {
+              "id": 2162052.600000024,
+              "value": 99.5,
+              "color": "#F5D30F",
+              "comparator": "≥"
+            }
+          ]
+        },
         "autoSelectVisualization": false
       },
-      "visualization": "lineChart"
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      }
+    },
+    "80": {
+      "title": "Gateway Risk Assessment Response Latency",
+      "type": "data",
+      "query": "timeseries \n  latency_avg = avg(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_max = max(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_min = min(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  by: { apiname },\n  filter: { aws.account.id == $SelectedAWSAccount }\n| filter apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsRename `API Name` = apiname\n| fieldsAdd\n  Min = arrayMin(latency_min),\n  Avg = arrayAvg(latency_avg),\n  P95 = arrayPercentile(latency_avg, 95),\n  P99 = arrayPercentile(latency_avg, 99),\n  Max = arrayMax(latency_max)\n| fields `API Name`, Min, Avg, P95, P99, Max",
+      "visualization": "table",
+      "visualizationSettings": {
+        "autoSelectVisualization": false,
+        "unitsOverrides": [
+          {
+            "identifier": "Min",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813591470
+          },
+          {
+            "identifier": "Avg",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813657191
+          },
+          {
+            "identifier": "P95",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813657610
+          },
+          {
+            "identifier": "P99",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813657990
+          },
+          {
+            "identifier": "Max",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813658329
+          }
+        ],
+        "thresholds": [
+          {
+            "id": 1,
+            "field": "Min",
+            "title": "",
+            "isEnabled": true,
+            "rules": [
+              {
+                "id": 0,
+                "color": "#7DC540",
+                "comparator": "≥",
+                "label": "",
+                "value": 0
+              },
+              {
+                "id": 1,
+                "color": "#F5D30F",
+                "comparator": "≥",
+                "label": "",
+                "value": 500
+              },
+              {
+                "id": 2,
+                "color": "#DC172A",
+                "comparator": "≥",
+                "label": "",
+                "value": 1000
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "field": "Avg",
+            "title": "",
+            "isEnabled": true,
+            "rules": [
+              {
+                "id": 0,
+                "color": "#7DC540",
+                "comparator": "≥",
+                "label": "",
+                "value": 0
+              },
+              {
+                "id": 1,
+                "color": "#F5D30F",
+                "comparator": "≥",
+                "label": "",
+                "value": 500
+              },
+              {
+                "id": 2,
+                "color": "#DC172A",
+                "comparator": "≥",
+                "label": "",
+                "value": 1000
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "field": "P95",
+            "title": "",
+            "isEnabled": true,
+            "rules": [
+              {
+                "id": 0,
+                "color": "#7DC540",
+                "comparator": "≥",
+                "label": "",
+                "value": 0
+              },
+              {
+                "id": 1,
+                "color": "#F5D30F",
+                "comparator": "≥",
+                "label": "",
+                "value": 500
+              },
+              {
+                "id": 2,
+                "color": "#DC172A",
+                "comparator": "≥",
+                "label": "",
+                "value": 1000
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "field": "P99",
+            "title": "",
+            "isEnabled": true,
+            "rules": [
+              {
+                "id": 0,
+                "color": "#7DC540",
+                "comparator": "≥",
+                "label": "",
+                "value": 0
+              },
+              {
+                "id": 1,
+                "color": "#F5D30F",
+                "comparator": "≥",
+                "label": "",
+                "value": 1250
+              },
+              {
+                "id": 2,
+                "color": "#DC172A",
+                "comparator": "≥",
+                "label": "",
+                "value": 2500
+              }
+            ]
+          },
+          {
+            "id": 5,
+            "field": "Max",
+            "title": "",
+            "isEnabled": true,
+            "rules": [
+              {
+                "id": 0,
+                "color": "#7DC540",
+                "comparator": "≥",
+                "label": "",
+                "value": 0
+              },
+              {
+                "id": 1,
+                "color": "#F5D30F",
+                "comparator": "≥",
+                "label": "",
+                "value": 2500
+              },
+              {
+                "id": 2,
+                "color": "#DC172A",
+                "comparator": "≥",
+                "label": "",
+                "value": 5000
+              }
+            ]
+          }
+        ],
+        "table": {
+          "colorThresholdTarget": "background",
+          "hideColumnsForLargeResults": true,
+          "rowDensity": "comfortable",
+          "sortBy": [{ "columnId": "[\"P99\"]", "direction": "ascending" }],
+          "selectedColumnForRowThreshold": "Min"
+        }
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      }
+    },
+    "81": {
+      "title": "Gateway Other Response Latency",
+      "type": "data",
+      "query": "timeseries \n  latency_avg = avg(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_max = max(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_min = min(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  by: { apiname },\n  filter: { aws.account.id == $SelectedAWSAccount }\n| filterOut apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsRename `API Name` = apiname\n| fieldsAdd\n  Min = arrayMin(latency_min),\n  Avg = arrayAvg(latency_avg),\n  P95 = arrayPercentile(latency_avg, 95),\n  P99 = arrayPercentile(latency_avg, 99),\n  Max = arrayMax(latency_max)\n| fields `API Name`, Min, Avg, P95, P99, Max",
+      "visualization": "table",
+      "visualizationSettings": {
+        "autoSelectVisualization": false,
+        "unitsOverrides": [
+          {
+            "identifier": "Min",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813591470
+          },
+          {
+            "identifier": "Avg",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813657191
+          },
+          {
+            "identifier": "P95",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813657610
+          },
+          {
+            "identifier": "P99",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813657990
+          },
+          {
+            "identifier": "Max",
+            "unitCategory": "time",
+            "baseUnit": "millisecond",
+            "displayUnit": null,
+            "decimals": null,
+            "suffix": "",
+            "delimiter": false,
+            "added": 1772813658329
+          }
+        ],
+        "thresholds": [],
+        "table": {
+          "colorThresholdTarget": "background",
+          "hideColumnsForLargeResults": true,
+          "rowDensity": "comfortable",
+          "sortBy": [{ "columnId": "[\"P99\"]", "direction": "ascending" }],
+          "selectedColumnForRowThreshold": "Min"
+        }
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      }
+    },
+    "82": {
+      "title": "Gateway Other Availability",
+      "description": "A percentage of success responses to 5xx responses. 4xx errors are not included.",
+      "type": "data",
+      "query": "timeseries { `5xxErrorByAccountIdApiNameRegionStage` = sum(cloud.aws.apigateway.5xxErrorByAccountIdApiNameRegionStage), countByAccountIdApiNameRegion = sum(cloud.aws.apigateway.countByAccountIdApiNameRegion)}, \nby: { apiname },\nfilter: { aws.account.id == $SelectedAWSAccount }\n| filterOut apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsAdd ErrorCount = arraySum(`5xxErrorByAccountIdApiNameRegionStage`)\n| fieldsAdd TotalCount = arraySum(`countByAccountIdApiNameRegion`)\n| summarize\n    ErrorCount = sum(ErrorCount),\n    TotalCount = sum(TotalCount)\n| fieldsAdd `Success %` = ((TotalCount - ErrorCount) / TotalCount) * 100.0\n| fields `Success %`",
+      "visualization": "gauge",
+      "visualizationSettings": {
+        "unitsOverrides": [
+          {
+            "identifier": "Success %",
+            "unitCategory": "percentage",
+            "baseUnit": "percent",
+            "displayUnit": null,
+            "decimals": 3,
+            "suffix": "",
+            "delimiter": true,
+            "added": 1773144594244
+          }
+        ],
+        "colorModeType": {
+          "color": "#DC172A",
+          "customNumericColors": [
+            {
+              "id": 2161353.200000018,
+              "value": 100,
+              "color": "#7DC540",
+              "comparator": "≥"
+            },
+            {
+              "id": 2162052.600000024,
+              "value": 99.5,
+              "color": "#F5D30F",
+              "comparator": "≥"
+            }
+          ]
+        },
+        "autoSelectVisualization": false
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      }
     }
   },
   "layouts": {
-    "0": {
-      "x": 0,
-      "y": 0,
-      "w": 36,
-      "h": 2
-    },
-    "1": {
-      "x": 0,
-      "y": 2,
-      "w": 36,
-      "h": 1
-    },
-    "2": {
-      "x": 18,
-      "y": 3,
-      "w": 18,
-      "h": 10
-    },
-    "3": {
-      "x": 0,
-      "y": 13,
-      "w": 18,
-      "h": 10
-    },
-    "4": {
-      "x": 18,
-      "y": 19,
-      "w": 18,
-      "h": 4
-    },
-    "5": {
-      "x": 18,
-      "y": 13,
-      "w": 18,
-      "h": 3
-    },
-    "6": {
-      "x": 18,
-      "y": 16,
-      "w": 18,
-      "h": 3
-    },
-    "7": {
-      "x": 0,
-      "y": 23,
-      "w": 36,
-      "h": 4
-    },
-    "8": {
-      "x": 0,
-      "y": 27,
-      "w": 36,
-      "h": 1
-    },
-    "25": {
-      "x": 0,
-      "y": 28,
-      "w": 19,
-      "h": 9
-    },
-    "26": {
-      "x": 19,
-      "y": 28,
-      "w": 17,
-      "h": 9
-    },
-    "27": {
-      "x": 0,
-      "y": 37,
-      "w": 19,
-      "h": 9
-    },
-    "28": {
-      "x": 19,
-      "y": 37,
-      "w": 17,
-      "h": 9
-    },
-    "29": {
-      "x": 0,
-      "y": 55,
-      "w": 19,
-      "h": 9
-    },
-    "30": {
-      "x": 19,
-      "y": 46,
-      "w": 17,
-      "h": 9
-    },
-    "31": {
-      "x": 0,
-      "y": 71,
-      "w": 19,
-      "h": 9
-    },
-    "32": {
-      "x": 0,
-      "y": 64,
-      "w": 36,
-      "h": 7
-    },
-    "34": {
-      "x": 0,
-      "y": 3,
-      "w": 18,
-      "h": 10
-    },
-    "37": {
-      "x": 19,
-      "y": 55,
-      "w": 17,
-      "h": 9
-    },
-    "39": {
-      "x": 19,
-      "y": 71,
-      "w": 17,
-      "h": 9
-    },
-    "40": {
-      "x": 0,
-      "y": 80,
-      "w": 19,
-      "h": 9
-    },
-    "41": {
-      "x": 19,
-      "y": 80,
-      "w": 17,
-      "h": 9
-    },
-    "42": {
-      "x": 0,
-      "y": 89,
-      "w": 19,
-      "h": 9
-    },
-    "50": {
-      "x": 0,
-      "y": 46,
-      "w": 19,
-      "h": 9
-    },
-    "51": {
-      "x": 0,
-      "y": 98,
-      "w": 36,
-      "h": 1
-    },
-    "52": {
-      "x": 0,
-      "y": 99,
-      "w": 19,
-      "h": 9
-    },
-    "53": {
-      "x": 0,
-      "y": 108,
-      "w": 19,
-      "h": 9
-    },
-    "54": {
-      "x": 19,
-      "y": 99,
-      "w": 17,
-      "h": 9
-    },
-    "55": {
-      "x": 0,
-      "y": 117,
-      "w": 19,
-      "h": 9
-    },
-    "56": {
-      "x": 19,
-      "y": 108,
-      "w": 17,
-      "h": 9
-    },
-    "57": {
-      "x": 0,
-      "y": 126,
-      "w": 36,
-      "h": 1
-    },
-    "62": {
-      "x": 0,
-      "y": 127,
-      "w": 18,
-      "h": 7
-    },
-    "63": {
-      "x": 18,
-      "y": 127,
-      "w": 18,
-      "h": 7
-    },
-    "64": {
-      "x": 0,
-      "y": 134,
-      "w": 18,
-      "h": 8
-    },
-    "65": {
-      "x": 18,
-      "y": 134,
-      "w": 18,
-      "h": 8
-    },
-    "67": {
-      "x": 0,
-      "y": 142,
-      "w": 18,
-      "h": 8
-    },
-    "68": {
-      "x": 0,
-      "y": 150,
-      "w": 36,
-      "h": 2
-    },
-    "69": {
-      "x": 0,
-      "y": 152,
-      "w": 18,
-      "h": 7
-    },
-    "70": {
-      "x": 18,
-      "y": 152,
-      "w": 18,
-      "h": 7
-    },
-    "71": {
-      "x": 0,
-      "y": 159,
-      "w": 18,
-      "h": 8
-    },
-    "72": {
-      "x": 18,
-      "y": 159,
-      "w": 18,
-      "h": 8
-    },
-    "73": {
-      "x": 0,
-      "y": 167,
-      "w": 18,
-      "h": 7
-    },
-    "74": {
-      "x": 0,
-      "y": 175,
-      "w": 18,
-      "h": 6
-    },
-    "75": {
-      "x": 0,
-      "y": 174,
-      "w": 27,
-      "h": 1
-    },
-    "76": {
-      "x": 18,
-      "y": 175,
-      "w": 18,
-      "h": 6
-    },
-    "77": {
-      "x": 18,
-      "y": 181,
-      "w": 18,
-      "h": 6
-    },
-    "78": {
-      "x": 0,
-      "y": 181,
-      "w": 18,
-      "h": 6
-    }
+    "0": { "x": 0, "y": 0, "w": 36, "h": 2 },
+    "1": { "x": 0, "y": 2, "w": 36, "h": 1 },
+    "2": { "x": 18, "y": 11, "w": 18, "h": 10 },
+    "3": { "x": 0, "y": 21, "w": 18, "h": 10 },
+    "4": { "x": 18, "y": 27, "w": 18, "h": 4 },
+    "5": { "x": 18, "y": 21, "w": 18, "h": 3 },
+    "6": { "x": 18, "y": 24, "w": 18, "h": 3 },
+    "7": { "x": 0, "y": 31, "w": 36, "h": 4 },
+    "8": { "x": 0, "y": 35, "w": 36, "h": 1 },
+    "25": { "x": 0, "y": 36, "w": 19, "h": 9 },
+    "26": { "x": 19, "y": 36, "w": 17, "h": 9 },
+    "27": { "x": 0, "y": 45, "w": 19, "h": 9 },
+    "28": { "x": 19, "y": 45, "w": 17, "h": 9 },
+    "29": { "x": 0, "y": 63, "w": 19, "h": 9 },
+    "30": { "x": 19, "y": 54, "w": 17, "h": 9 },
+    "31": { "x": 0, "y": 79, "w": 19, "h": 9 },
+    "32": { "x": 0, "y": 72, "w": 36, "h": 7 },
+    "34": { "x": 0, "y": 11, "w": 18, "h": 10 },
+    "37": { "x": 19, "y": 63, "w": 17, "h": 9 },
+    "39": { "x": 19, "y": 79, "w": 17, "h": 9 },
+    "40": { "x": 0, "y": 88, "w": 19, "h": 9 },
+    "41": { "x": 19, "y": 88, "w": 17, "h": 9 },
+    "42": { "x": 0, "y": 97, "w": 19, "h": 9 },
+    "50": { "x": 0, "y": 54, "w": 19, "h": 9 },
+    "51": { "x": 0, "y": 106, "w": 36, "h": 1 },
+    "52": { "x": 0, "y": 107, "w": 19, "h": 9 },
+    "53": { "x": 0, "y": 116, "w": 19, "h": 9 },
+    "54": { "x": 19, "y": 107, "w": 17, "h": 9 },
+    "55": { "x": 0, "y": 125, "w": 19, "h": 9 },
+    "56": { "x": 19, "y": 116, "w": 17, "h": 9 },
+    "57": { "x": 0, "y": 134, "w": 36, "h": 1 },
+    "62": { "x": 0, "y": 135, "w": 18, "h": 7 },
+    "63": { "x": 18, "y": 135, "w": 18, "h": 7 },
+    "64": { "x": 0, "y": 142, "w": 18, "h": 8 },
+    "65": { "x": 18, "y": 142, "w": 18, "h": 8 },
+    "67": { "x": 0, "y": 150, "w": 18, "h": 8 },
+    "68": { "x": 0, "y": 158, "w": 36, "h": 2 },
+    "69": { "x": 0, "y": 160, "w": 18, "h": 7 },
+    "70": { "x": 18, "y": 160, "w": 18, "h": 7 },
+    "71": { "x": 0, "y": 167, "w": 18, "h": 8 },
+    "72": { "x": 18, "y": 167, "w": 18, "h": 8 },
+    "73": { "x": 0, "y": 175, "w": 18, "h": 7 },
+    "74": { "x": 0, "y": 183, "w": 18, "h": 6 },
+    "75": { "x": 0, "y": 182, "w": 27, "h": 1 },
+    "76": { "x": 18, "y": 183, "w": 18, "h": 6 },
+    "77": { "x": 18, "y": 189, "w": 18, "h": 6 },
+    "78": { "x": 0, "y": 189, "w": 18, "h": 6 },
+    "79": { "x": 0, "y": 3, "w": 12, "h": 4 },
+    "80": { "x": 12, "y": 3, "w": 24, "h": 4 },
+    "81": { "x": 12, "y": 7, "w": 24, "h": 4 },
+    "82": { "x": 0, "y": 7, "w": 12, "h": 4 }
   },
   "importedWithCode": true,
   "settings": {
-    "gridLayout": {
-      "mode": "responsive",
-      "columnsCount": 36
-    },
+    "gridLayout": { "mode": "responsive", "columnsCount": 36 },
     "defaultTimeframe": {
-      "value": {
-        "from": "now()-2h",
-        "to": "now()"
-      },
+      "value": { "from": "now()-2h", "to": "now()" },
       "enabled": false
     },
-    "defaultSegments": {
-      "value": [],
-      "enabled": false
-    }
+    "defaultSegments": { "value": [], "enabled": false }
   },
   "annotations": []
 }

--- a/documents/fraud/ticf-cri/ticf-cri-infrastructure.json
+++ b/documents/fraud/ticf-cri/ticf-cri-infrastructure.json
@@ -183,8 +183,7 @@
                 "latencyByAccountIdApiNameRegion"
               ],
               "value": "sparkline",
-              "id": 1741626519288,
-              "disableRemoval": false
+              "id": 1741626519288
             }
           ],
           "hiddenColumns": [
@@ -246,8 +245,7 @@
             {
               "fields": ["4xxErrorByAccountIdApiNameRegionStage"],
               "value": "sparkline",
-              "id": 1741626519495,
-              "disableRemoval": false
+              "id": 1741626519495
             }
           ],
           "hiddenColumns": [
@@ -292,8 +290,7 @@
             {
               "fields": ["5xxErrorByAccountIdApiNameRegionStage"],
               "value": "sparkline",
-              "id": 1741626519500,
-              "disableRemoval": false
+              "id": 1741626519500
             }
           ],
           "hiddenColumns": [
@@ -338,8 +335,7 @@
             {
               "fields": ["blockedRequestsByAccountIdRegionRuleWebACL"],
               "value": "sparkline",
-              "id": 1741626519436,
-              "disableRemoval": false
+              "id": 1741626519436
             }
           ],
           "hiddenColumns": [
@@ -944,9 +940,13 @@
           "truncationMode": "middle",
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
+          "hiddenLegendFields": [
+            "interval",
+            "errorCount",
+            "errorsByAccountIdFunctionNameRegion"
+          ],
           "fieldMapping": { "leftAxisValues": ["a"], "timestamp": "timeframe" }
         },
-        "dataMapping": { "displayedFields": ["statuscode", "service"] },
         "autoSelectVisualization": false
       }
     },
@@ -982,8 +982,8 @@
         "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
-        "tileTimeframeEnabled": true
+        "tileTimeframeEnabled": true,
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" }
       }
     },
     "53": {
@@ -996,12 +996,17 @@
           "truncationMode": "middle",
           "xAxisLabel": "timeframe",
           "xAxisScaling": "analyzedTimeframe",
+          "hiddenLegendFields": [
+            "successfulRequestLatencyByAccountIdOperationRegionTableName",
+            "successfulRequestLatencyByAccountIdOperationRegionTableName.0",
+            "successfulRequestLatencyByAccountIdOperationRegionTableName.1",
+            "interval"
+          ],
           "fieldMapping": {
             "leftAxisValues": ["writeThrottleEvents"],
             "timestamp": "timeframe"
           }
         },
-        "dataMapping": { "displayedFields": ["tablename"] },
         "autoSelectVisualization": false,
         "unitsOverrides": []
       },
@@ -1017,8 +1022,8 @@
         "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
-        "tileTimeframeEnabled": true
+        "tileTimeframeEnabled": true,
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" }
       }
     },
     "54": {
@@ -1052,8 +1057,8 @@
         "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
-        "tileTimeframeEnabled": true
+        "tileTimeframeEnabled": true,
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" }
       }
     },
     "55": {
@@ -1087,8 +1092,8 @@
         "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
-        "tileTimeframeEnabled": true
+        "tileTimeframeEnabled": true,
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" }
       }
     },
     "56": {
@@ -1122,8 +1127,8 @@
         "davisVisualization": { "isAvailable": true }
       },
       "timeframe": {
-        "tileTimeframe": { "from": "now()-365d", "to": "now()" },
-        "tileTimeframeEnabled": true
+        "tileTimeframeEnabled": true,
+        "tileTimeframe": { "from": "now()-365d", "to": "now()" }
       }
     },
     "57": { "type": "markdown", "content": "## SQS Metrics" },
@@ -1902,6 +1907,81 @@
       }
     },
     "81": {
+      "title": "Gateway Other Availability",
+      "description": "A percentage of success responses to 5xx responses. 4xx errors are not included.",
+      "type": "data",
+      "query": "timeseries { `5xxErrorByAccountIdApiNameRegionStage` = sum(cloud.aws.apigateway.5xxErrorByAccountIdApiNameRegionStage), countByAccountIdApiNameRegion = sum(cloud.aws.apigateway.countByAccountIdApiNameRegion)}, \nby: { apiname },\nfilter: { aws.account.id == $SelectedAWSAccount }\n| filterOut apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsAdd ErrorCount = arraySum(`5xxErrorByAccountIdApiNameRegionStage`)\n| fieldsAdd TotalCount = arraySum(`countByAccountIdApiNameRegion`)\n| summarize\n    ErrorCount = sum(ErrorCount),\n    TotalCount = sum(TotalCount)\n| fieldsAdd `Success %` = ((TotalCount - ErrorCount) / TotalCount) * 100.0\n| fields `Success %`",
+      "visualization": "gauge",
+      "visualizationSettings": {
+        "unitsOverrides": [
+          {
+            "identifier": "Success %",
+            "unitCategory": "percentage",
+            "baseUnit": "percent",
+            "displayUnit": null,
+            "decimals": 3,
+            "suffix": "",
+            "delimiter": true,
+            "added": 1773144594244
+          }
+        ],
+        "coloring": {
+          "colorRules": [
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#DC172A",
+              "field": "",
+              "value": null
+            },
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#F5D30F",
+              "field": "",
+              "value": 99.5
+            },
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#7DC540",
+              "field": "",
+              "value": 100
+            }
+          ]
+        },
+        "colorModeType": {
+          "color": "#DC172A",
+          "customNumericColors": [
+            {
+              "id": 2161353.200000018,
+              "value": 100,
+              "color": "#7DC540",
+              "comparator": "≥"
+            },
+            {
+              "id": 2162052.600000024,
+              "value": 99.5,
+              "color": "#F5D30F",
+              "comparator": "≥"
+            }
+          ]
+        },
+        "autoSelectVisualization": false
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      },
+      "davis": {
+        "enabled": false,
+        "davisVisualization": { "isAvailable": true }
+      }
+    },
+    "82": {
       "title": "Gateway Other Response Latency",
       "type": "data",
       "query": "timeseries \n  latency_avg = avg(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_max = max(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_min = min(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  by: { apiname },\n  filter: { aws.account.id == $SelectedAWSAccount }\n| filterOut apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsRename `API Name` = apiname\n| fieldsAdd\n  Min = arrayMin(latency_min),\n  Avg = arrayAvg(latency_avg),\n  P95 = arrayPercentile(latency_avg, 95),\n  P99 = arrayPercentile(latency_avg, 99),\n  Max = arrayMax(latency_max)\n| fields `API Name`, Min, Avg, P95, P99, Max",
@@ -1979,81 +2059,6 @@
         "enabled": false,
         "davisVisualization": { "isAvailable": true }
       }
-    },
-    "82": {
-      "title": "Gateway Other Availability",
-      "description": "A percentage of success responses to 5xx responses. 4xx errors are not included.",
-      "type": "data",
-      "query": "timeseries { `5xxErrorByAccountIdApiNameRegionStage` = sum(cloud.aws.apigateway.5xxErrorByAccountIdApiNameRegionStage), countByAccountIdApiNameRegion = sum(cloud.aws.apigateway.countByAccountIdApiNameRegion)}, \nby: { apiname },\nfilter: { aws.account.id == $SelectedAWSAccount }\n| filterOut apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsAdd ErrorCount = arraySum(`5xxErrorByAccountIdApiNameRegionStage`)\n| fieldsAdd TotalCount = arraySum(`countByAccountIdApiNameRegion`)\n| summarize\n    ErrorCount = sum(ErrorCount),\n    TotalCount = sum(TotalCount)\n| fieldsAdd `Success %` = ((TotalCount - ErrorCount) / TotalCount) * 100.0\n| fields `Success %`",
-      "visualization": "gauge",
-      "visualizationSettings": {
-        "unitsOverrides": [
-          {
-            "identifier": "Success %",
-            "unitCategory": "percentage",
-            "baseUnit": "percent",
-            "displayUnit": null,
-            "decimals": 3,
-            "suffix": "",
-            "delimiter": true,
-            "added": 1773144594244
-          }
-        ],
-        "coloring": {
-          "colorRules": [
-            {
-              "colorMode": "custom-color",
-              "comparator": "≥",
-              "customColor": "#DC172A",
-              "field": "",
-              "value": null
-            },
-            {
-              "colorMode": "custom-color",
-              "comparator": "≥",
-              "customColor": "#F5D30F",
-              "field": "",
-              "value": 99.5
-            },
-            {
-              "colorMode": "custom-color",
-              "comparator": "≥",
-              "customColor": "#7DC540",
-              "field": "",
-              "value": 100
-            }
-          ]
-        },
-        "colorModeType": {
-          "color": "#DC172A",
-          "customNumericColors": [
-            {
-              "id": 2161353.200000018,
-              "value": 100,
-              "color": "#7DC540",
-              "comparator": "≥"
-            },
-            {
-              "id": 2162052.600000024,
-              "value": 99.5,
-              "color": "#F5D30F",
-              "comparator": "≥"
-            }
-          ]
-        },
-        "autoSelectVisualization": false
-      },
-      "querySettings": {
-        "maxResultRecords": 1000,
-        "defaultScanLimitGbytes": 500,
-        "maxResultMegaBytes": 1,
-        "defaultSamplingRatio": 10,
-        "enableSampling": false
-      },
-      "davis": {
-        "enabled": false,
-        "davisVisualization": { "isAvailable": true }
-      }
     }
   },
   "layouts": {
@@ -2106,8 +2111,8 @@
     "78": { "x": 0, "y": 189, "w": 18, "h": 6 },
     "79": { "x": 0, "y": 3, "w": 12, "h": 4 },
     "80": { "x": 12, "y": 3, "w": 24, "h": 4 },
-    "81": { "x": 12, "y": 7, "w": 24, "h": 4 },
-    "82": { "x": 0, "y": 7, "w": 12, "h": 4 }
+    "81": { "x": 0, "y": 7, "w": 12, "h": 4 },
+    "82": { "x": 12, "y": 7, "w": 24, "h": 4 }
   },
   "importedWithCode": true,
   "settings": {

--- a/documents/fraud/ticf-cri/ticf-cri-infrastructure.json
+++ b/documents/fraud/ticf-cri/ticf-cri-infrastructure.json
@@ -79,21 +79,16 @@
           },
           "gapPolicy": "connect"
         },
+        "dataMapping": {
+          "displayedFields": [
+            "apiname",
+            "Avg Latency",
+            "Max Latency",
+            "Min Latency"
+          ]
+        },
         "legend": { "ratio": 27 },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "countByAccountIdApiNameRegionStage",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
         "unitsOverrides": [
           {
             "identifier": "Avg Latency",
@@ -125,15 +120,7 @@
             "delimiter": false,
             "added": 1743762675242
           }
-        ],
-        "dataMapping": {
-          "displayedFields": [
-            "apiname",
-            "Avg Latency",
-            "Max Latency",
-            "Min Latency"
-          ]
-        }
+        ]
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -164,24 +151,11 @@
           },
           "gapPolicy": { "threshold": "1h" }
         },
-        "legend": { "ratio": 26 },
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "4xxErrorByAccountIdApiNameRegionStage",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
-        "unitsOverrides": [],
         "dataMapping": {
           "displayedFields": ["apiname", "Errors4xx", "Errors5xx"]
-        }
+        },
+        "legend": { "ratio": 26 },
+        "unitsOverrides": []
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -202,6 +176,17 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
+          "columnTypeOverrides": [
+            {
+              "fields": [
+                "countByAccountIdApiNameRegion",
+                "latencyByAccountIdApiNameRegion"
+              ],
+              "value": "sparkline",
+              "id": 1741626519288,
+              "disableRemoval": false
+            }
+          ],
           "hiddenColumns": [
             ["timeframe"],
             ["interval"],
@@ -213,32 +198,8 @@
             "[\"countByAccountIdApiNameRegion\"]": 112.14236450195312,
             "[\"API Name\"]": 336.9600830078125,
             "[\"Count\"]": 153.50868225097656
-          },
-          "columnTypeOverrides": [
-            {
-              "fields": [
-                "countByAccountIdApiNameRegion",
-                "latencyByAccountIdApiNameRegion"
-              ],
-              "value": "sparkline",
-              "id": 1741626519288,
-              "disableRemoval": false
-            }
-          ]
-        },
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "countByAccountIdApiNameRegion",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
           }
-        ],
+        },
         "unitsOverrides": [
           {
             "identifier": "Count",
@@ -281,11 +242,6 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
-          "hiddenColumns": [
-            ["timeframe"],
-            ["interval"],
-            ["4xxErrorByAccountIdApiNameRegionStage"]
-          ],
           "columnTypeOverrides": [
             {
               "fields": ["4xxErrorByAccountIdApiNameRegionStage"],
@@ -293,21 +249,13 @@
               "id": 1741626519495,
               "disableRemoval": false
             }
+          ],
+          "hiddenColumns": [
+            ["timeframe"],
+            ["interval"],
+            ["4xxErrorByAccountIdApiNameRegionStage"]
           ]
         },
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "4xxErrorByAccountIdApiNameRegionStage",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
         "unitsOverrides": [
           {
             "identifier": "4XX Error Count",
@@ -340,11 +288,6 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
-          "hiddenColumns": [
-            ["timeframe"],
-            ["interval"],
-            ["5xxErrorByAccountIdApiNameRegionStage"]
-          ],
           "columnTypeOverrides": [
             {
               "fields": ["5xxErrorByAccountIdApiNameRegionStage"],
@@ -352,21 +295,13 @@
               "id": 1741626519500,
               "disableRemoval": false
             }
+          ],
+          "hiddenColumns": [
+            ["timeframe"],
+            ["interval"],
+            ["5xxErrorByAccountIdApiNameRegionStage"]
           ]
         },
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "5xxErrorByAccountIdApiNameRegionStage",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
         "unitsOverrides": [
           {
             "identifier": "5XX Error Count",
@@ -399,6 +334,14 @@
       "visualization": "table",
       "visualizationSettings": {
         "table": {
+          "columnTypeOverrides": [
+            {
+              "fields": ["blockedRequestsByAccountIdRegionRuleWebACL"],
+              "value": "sparkline",
+              "id": 1741626519436,
+              "disableRemoval": false
+            }
+          ],
           "hiddenColumns": [
             ["timeframe"],
             ["interval"],
@@ -412,30 +355,9 @@
             "[\"Account\"]": 123.42535400390625,
             "[\"Region\"]": 107.5763931274414,
             "[\"Web ACL\"]": 503.3090515136719
-          },
-          "columnTypeOverrides": [
-            {
-              "fields": ["blockedRequestsByAccountIdRegionRuleWebACL"],
-              "value": "sparkline",
-              "id": 1741626519436,
-              "disableRemoval": false
-            }
-          ]
+          }
         },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "blockedRequestsByAccountIdRegionRuleWebACL",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
         "unitsOverrides": [
           {
             "identifier": "blockedRequestsByAccountIdRegionRuleWebACL",
@@ -488,9 +410,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        "dataMapping": { "displayedFields": ["functionname"] },
+        "autoSelectVisualization": false
       }
     },
     "26": {
@@ -513,8 +434,19 @@
           }
         },
         "legend": { "ratio": 15 },
+        "coloring": {
+          "colorRules": [
+            {
+              "field": "DT.name",
+              "comparator": "= *value*",
+              "value": "",
+              "type": "string",
+              "colorMode": "color-palette",
+              "colorPalette": "categorical"
+            }
+          ]
+        },
         "autoSelectVisualization": false,
-        "thresholds": [],
         "unitsOverrides": [
           {
             "identifier": "invocationsSum",
@@ -544,8 +476,8 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["functionname"] },
         "autoSelectVisualization": false,
-        "thresholds": [],
         "unitsOverrides": [
           {
             "identifier": "durationByAccountIdFunctionNameRegion",
@@ -557,8 +489,7 @@
             "delimiter": false,
             "added": 1740153156962
           }
-        ],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        ]
       }
     },
     "28": {
@@ -579,9 +510,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        "dataMapping": { "displayedFields": ["functionname"] },
+        "autoSelectVisualization": false
       }
     },
     "29": {
@@ -600,8 +530,8 @@
           },
           "gapPolicy": "connect"
         },
+        "dataMapping": { "displayedFields": ["functionname"] },
         "autoSelectVisualization": false,
-        "thresholds": [],
         "unitsOverrides": [
           {
             "identifier": "errorRate",
@@ -613,8 +543,7 @@
             "delimiter": false,
             "added": 1740155455179
           }
-        ],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        ]
       }
     },
     "30": {
@@ -632,9 +561,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        "dataMapping": { "displayedFields": ["functionname"] },
+        "autoSelectVisualization": false
       }
     },
     "31": {
@@ -652,42 +580,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": 1,
-            "field": "",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-ideal-default, #2f6863)"
-                },
-                "comparator": "≥",
-                "label": ""
-              },
-              {
-                "id": 1,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-warning-default, #eca440)"
-                },
-                "comparator": "≥",
-                "label": ""
-              },
-              {
-                "id": 2,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-critical-default, #c4233b)"
-                },
-                "comparator": "≥",
-                "label": ""
-              }
-            ]
-          }
-        ],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        "dataMapping": { "displayedFields": ["functionname"] },
+        "autoSelectVisualization": false
       }
     },
     "32": {
@@ -714,7 +608,6 @@
           "gapPolicy": "connect"
         },
         "autoSelectVisualization": false,
-        "thresholds": [],
         "unitsOverrides": [
           {
             "identifier": "Count",
@@ -780,43 +673,40 @@
           },
           "gapPolicy": "connect"
         },
+        "dataMapping": { "displayedFields": ["apiname"] },
         "legend": { "ratio": 26 },
+        "coloring": {
+          "thresholdRules": [
+            {
+              "color": "#EEA746",
+              "min": 5000,
+              "max": 8000,
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            },
+            {
+              "color": "var(--dt-colors-charts-categorical-color-14-default, #d56b1a)",
+              "min": 8000,
+              "max": 10000,
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            },
+            {
+              "color": "var(--dt-colors-charts-status-critical-default, #c4233b)",
+              "min": 10000,
+              "max": null,
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            }
+          ]
+        },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": 1,
-            "field": "",
-            "title": "Account Limit Threshold",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": "#EEA746",
-                "comparator": "≥",
-                "label": "",
-                "value": 5000
-              },
-              {
-                "id": 1,
-                "color": {
-                  "Default": "var(--dt-colors-charts-categorical-color-14-default, #d56b1a)"
-                },
-                "comparator": "≥",
-                "label": "",
-                "value": 8000
-              },
-              {
-                "id": 2,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-critical-default, #c4233b)"
-                },
-                "comparator": "≥",
-                "label": "",
-                "value": 10000
-              }
-            ]
-          }
-        ],
         "unitsOverrides": [
           {
             "identifier": "Latency",
@@ -828,8 +718,7 @@
             "delimiter": false,
             "added": 1740138132831
           }
-        ],
-        "dataMapping": { "displayedFields": ["apiname"] }
+        ]
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -893,47 +782,43 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": 1,
-            "field": "",
-            "title": "Account Limit Threshold",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": "#EEA746",
-                "comparator": "≥",
-                "label": "",
-                "value": 500
-              },
-              {
-                "id": 1,
-                "color": {
-                  "Default": "var(--dt-colors-charts-categorical-color-14-default, #d56b1a)"
-                },
-                "comparator": "≥",
-                "label": "",
-                "value": 800
-              },
-              {
-                "id": 2,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-critical-default, #c4233b)"
-                },
-                "comparator": "≥",
-                "label": "",
-                "value": 1000
-              }
-            ]
-          }
-        ],
         "dataMapping": {
           "displayedFields": [
             "concurrentExecutionsByAccountIdFunctionNameRegion"
           ]
-        }
+        },
+        "coloring": {
+          "thresholdRules": [
+            {
+              "color": "#EEA746",
+              "min": 500,
+              "max": 800,
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            },
+            {
+              "color": "var(--dt-colors-charts-categorical-color-14-default, #d56b1a)",
+              "min": 800,
+              "max": 1000,
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            },
+            {
+              "color": "var(--dt-colors-charts-status-critical-default, #c4233b)",
+              "min": 1000,
+              "max": null,
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            }
+          ]
+        },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -965,8 +850,7 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": []
+        "autoSelectVisualization": false
       }
     },
     "40": {
@@ -984,8 +868,8 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["functionname"] },
         "autoSelectVisualization": false,
-        "thresholds": [],
         "unitsOverrides": [
           {
             "identifier": "asyncEventAge",
@@ -997,8 +881,7 @@
             "delimiter": false,
             "added": 1741623406425
           }
-        ],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        ]
       }
     },
     "41": {
@@ -1016,9 +899,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        "dataMapping": { "displayedFields": ["functionname"] },
+        "autoSelectVisualization": false
       }
     },
     "42": {
@@ -1036,8 +918,8 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["functionname"] },
         "autoSelectVisualization": false,
-        "thresholds": [],
         "unitsOverrides": [
           {
             "identifier": "iteratorAge",
@@ -1049,8 +931,7 @@
             "delimiter": false,
             "added": 1741623770672
           }
-        ],
-        "dataMapping": { "displayedFields": ["functionname"] }
+        ]
       }
     },
     "50": {
@@ -1065,9 +946,8 @@
           "xAxisScaling": "analyzedTimeframe",
           "fieldMapping": { "leftAxisValues": ["a"], "timestamp": "timeframe" }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["statuscode", "service"] }
+        "dataMapping": { "displayedFields": ["statuscode", "service"] },
+        "autoSelectVisualization": false
       }
     },
     "51": { "type": "markdown", "content": "## Dynamo DB Metrics" },
@@ -1086,22 +966,9 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["tablename"] },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
-        "unitsOverrides": [],
-        "dataMapping": { "displayedFields": ["tablename"] }
+        "unitsOverrides": []
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1134,22 +1001,9 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["tablename"] },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
-        "unitsOverrides": [],
-        "dataMapping": { "displayedFields": ["tablename"] }
+        "unitsOverrides": []
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1182,22 +1036,9 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["tablename"] },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
-        "unitsOverrides": [],
-        "dataMapping": { "displayedFields": ["tablename"] }
+        "unitsOverrides": []
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1230,22 +1071,9 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["tablename"] },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
-        "unitsOverrides": [],
-        "dataMapping": { "displayedFields": ["tablename"] }
+        "unitsOverrides": []
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1278,22 +1106,9 @@
             "timestamp": "timeframe"
           }
         },
+        "dataMapping": { "displayedFields": ["tablename", "operation"] },
         "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": "0",
-            "title": "",
-            "field": "successfulRequestLatencyByAccountIdOperationRegionTableName",
-            "rules": [
-              { "id": "0", "label": "", "comparator": "≥", "color": "#7dc540" },
-              { "id": "1", "label": "", "comparator": "≥", "color": "#f5d30f" },
-              { "id": "2", "label": "", "comparator": "≥", "color": "#dc172a" }
-            ],
-            "isEnabled": true
-          }
-        ],
-        "unitsOverrides": [],
-        "dataMapping": { "displayedFields": ["tablename", "operation"] }
+        "unitsOverrides": []
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1342,9 +1157,28 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "coloring": {
+          "colorRules": [
+            {
+              "field": "DT.name",
+              "comparator": "= *value*",
+              "value": "",
+              "type": "string",
+              "colorMode": "color-palette",
+              "colorPalette": "categorical"
+            },
+            {
+              "colorMode": "custom-color",
+              "type": "string",
+              "field": "DT.name",
+              "comparator": "=",
+              "customColor": "#b3007d",
+              "value": "count(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion)"
+            }
+          ]
+        },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1384,9 +1218,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1425,9 +1258,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1466,9 +1298,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1494,35 +1325,31 @@
       "visualizationSettings": {
         "chartSettings": { "xAxisScaling": "analyzedTimeframe" },
         "legend": { "ratio": 23 },
-        "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": 1,
-            "field": "",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 1,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-warning-default, #eca440)"
-                },
-                "comparator": "≥",
-                "label": "50 percent ",
-                "value": 21600
-              },
-              {
-                "id": 2,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-critical-default, #c4233b)"
-                },
-                "comparator": "≥",
-                "label": "100 percent",
-                "value": 43200
-              }
-            ]
-          }
-        ]
+        "coloring": {
+          "thresholdRules": [
+            {
+              "color": "var(--dt-colors-charts-status-warning-default, #eca440)",
+              "min": 21600,
+              "max": 43200,
+              "label": "50 percent ",
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            },
+            {
+              "color": "var(--dt-colors-charts-status-critical-default, #c4233b)",
+              "min": 43200,
+              "max": null,
+              "label": "100 percent",
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            }
+          ]
+        },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1571,9 +1398,28 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "coloring": {
+          "colorRules": [
+            {
+              "field": "DT.name",
+              "comparator": "= *value*",
+              "value": "",
+              "type": "string",
+              "colorMode": "color-palette",
+              "colorPalette": "categorical"
+            },
+            {
+              "colorMode": "custom-color",
+              "type": "string",
+              "field": "DT.name",
+              "comparator": "=",
+              "customColor": "#b3007d",
+              "value": "count(cloud.aws.sqs.numberOfMessagesSentByAccountIdQueueNameRegion)"
+            }
+          ]
+        },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1613,9 +1459,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1654,9 +1499,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1695,9 +1539,8 @@
             "timestamp": "timeframe"
           }
         },
-        "autoSelectVisualization": false,
-        "thresholds": [],
-        "dataMapping": { "displayedFields": ["queuename"] }
+        "dataMapping": { "displayedFields": ["queuename"] },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1723,35 +1566,31 @@
       "visualizationSettings": {
         "chartSettings": { "xAxisScaling": "analyzedTimeframe" },
         "legend": { "ratio": 23 },
-        "autoSelectVisualization": false,
-        "thresholds": [
-          {
-            "id": 1,
-            "field": "",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 1,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-warning-default, #eca440)"
-                },
-                "comparator": "≥",
-                "label": "80 percent ",
-                "value": 103680
-              },
-              {
-                "id": 2,
-                "color": {
-                  "Default": "var(--dt-colors-charts-status-critical-default, #c4233b)"
-                },
-                "comparator": "≥",
-                "label": "100 percent",
-                "value": 129680
-              }
-            ]
-          }
-        ]
+        "coloring": {
+          "thresholdRules": [
+            {
+              "color": "var(--dt-colors-charts-status-warning-default, #eca440)",
+              "min": 103680,
+              "max": 129680,
+              "label": "80 percent ",
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            },
+            {
+              "color": "var(--dt-colors-charts-status-critical-default, #c4233b)",
+              "min": 129680,
+              "max": null,
+              "label": "100 percent",
+              "colorMode": "single-color",
+              "mode": "range",
+              "position": "left",
+              "strokeOnly": false
+            }
+          ]
+        },
+        "autoSelectVisualization": false
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -1818,6 +1657,31 @@
             "added": 1773144594244
           }
         ],
+        "coloring": {
+          "colorRules": [
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#DC172A",
+              "field": "",
+              "value": null
+            },
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#F5D30F",
+              "field": "",
+              "value": 99.5
+            },
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#7DC540",
+              "field": "",
+              "value": 100
+            }
+          ]
+        },
         "colorModeType": {
           "color": "#DC172A",
           "customNumericColors": [
@@ -1855,6 +1719,122 @@
       "query": "timeseries \n  latency_avg = avg(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_max = max(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_min = min(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  by: { apiname },\n  filter: { aws.account.id == $SelectedAWSAccount }\n| filter apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsRename `API Name` = apiname\n| fieldsAdd\n  Min = arrayMin(latency_min),\n  Avg = arrayAvg(latency_avg),\n  P95 = arrayPercentile(latency_avg, 95),\n  P99 = arrayPercentile(latency_avg, 99),\n  Max = arrayMax(latency_max)\n| fields `API Name`, Min, Avg, P95, P99, Max",
       "visualization": "table",
       "visualizationSettings": {
+        "table": {
+          "colorThresholdTarget": "background",
+          "hideColumnsForLargeResults": true,
+          "rowDensity": "comfortable",
+          "sortBy": [{ "columnId": "[\"P99\"]", "direction": "ascending" }],
+          "selectedColumnForRowThreshold": "Min"
+        },
+        "coloring": {
+          "colorRules": [
+            {
+              "value": 0,
+              "comparator": "≥",
+              "field": "Min",
+              "colorMode": "custom-color",
+              "customColor": "#7DC540"
+            },
+            {
+              "value": 500,
+              "comparator": "≥",
+              "field": "Min",
+              "colorMode": "custom-color",
+              "customColor": "#F5D30F"
+            },
+            {
+              "value": 1000,
+              "comparator": "≥",
+              "field": "Min",
+              "colorMode": "custom-color",
+              "customColor": "#DC172A"
+            },
+            {
+              "value": 0,
+              "comparator": "≥",
+              "field": "Avg",
+              "colorMode": "custom-color",
+              "customColor": "#7DC540"
+            },
+            {
+              "value": 500,
+              "comparator": "≥",
+              "field": "Avg",
+              "colorMode": "custom-color",
+              "customColor": "#F5D30F"
+            },
+            {
+              "value": 1000,
+              "comparator": "≥",
+              "field": "Avg",
+              "colorMode": "custom-color",
+              "customColor": "#DC172A"
+            },
+            {
+              "value": 0,
+              "comparator": "≥",
+              "field": "P95",
+              "colorMode": "custom-color",
+              "customColor": "#7DC540"
+            },
+            {
+              "value": 500,
+              "comparator": "≥",
+              "field": "P95",
+              "colorMode": "custom-color",
+              "customColor": "#F5D30F"
+            },
+            {
+              "value": 1000,
+              "comparator": "≥",
+              "field": "P95",
+              "colorMode": "custom-color",
+              "customColor": "#DC172A"
+            },
+            {
+              "value": 0,
+              "comparator": "≥",
+              "field": "P99",
+              "colorMode": "custom-color",
+              "customColor": "#7DC540"
+            },
+            {
+              "value": 1250,
+              "comparator": "≥",
+              "field": "P99",
+              "colorMode": "custom-color",
+              "customColor": "#F5D30F"
+            },
+            {
+              "value": 2500,
+              "comparator": "≥",
+              "field": "P99",
+              "colorMode": "custom-color",
+              "customColor": "#DC172A"
+            },
+            {
+              "value": 0,
+              "comparator": "≥",
+              "field": "Max",
+              "colorMode": "custom-color",
+              "customColor": "#7DC540"
+            },
+            {
+              "value": 2500,
+              "comparator": "≥",
+              "field": "Max",
+              "colorMode": "custom-color",
+              "customColor": "#F5D30F"
+            },
+            {
+              "value": 5000,
+              "comparator": "≥",
+              "field": "Max",
+              "colorMode": "custom-color",
+              "customColor": "#DC172A"
+            }
+          ]
+        },
         "autoSelectVisualization": false,
         "unitsOverrides": [
           {
@@ -1907,161 +1887,7 @@
             "delimiter": false,
             "added": 1772813658329
           }
-        ],
-        "thresholds": [
-          {
-            "id": 1,
-            "field": "Min",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": "#7DC540",
-                "comparator": "≥",
-                "label": "",
-                "value": 0
-              },
-              {
-                "id": 1,
-                "color": "#F5D30F",
-                "comparator": "≥",
-                "label": "",
-                "value": 500
-              },
-              {
-                "id": 2,
-                "color": "#DC172A",
-                "comparator": "≥",
-                "label": "",
-                "value": 1000
-              }
-            ]
-          },
-          {
-            "id": 2,
-            "field": "Avg",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": "#7DC540",
-                "comparator": "≥",
-                "label": "",
-                "value": 0
-              },
-              {
-                "id": 1,
-                "color": "#F5D30F",
-                "comparator": "≥",
-                "label": "",
-                "value": 500
-              },
-              {
-                "id": 2,
-                "color": "#DC172A",
-                "comparator": "≥",
-                "label": "",
-                "value": 1000
-              }
-            ]
-          },
-          {
-            "id": 3,
-            "field": "P95",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": "#7DC540",
-                "comparator": "≥",
-                "label": "",
-                "value": 0
-              },
-              {
-                "id": 1,
-                "color": "#F5D30F",
-                "comparator": "≥",
-                "label": "",
-                "value": 500
-              },
-              {
-                "id": 2,
-                "color": "#DC172A",
-                "comparator": "≥",
-                "label": "",
-                "value": 1000
-              }
-            ]
-          },
-          {
-            "id": 4,
-            "field": "P99",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": "#7DC540",
-                "comparator": "≥",
-                "label": "",
-                "value": 0
-              },
-              {
-                "id": 1,
-                "color": "#F5D30F",
-                "comparator": "≥",
-                "label": "",
-                "value": 1250
-              },
-              {
-                "id": 2,
-                "color": "#DC172A",
-                "comparator": "≥",
-                "label": "",
-                "value": 2500
-              }
-            ]
-          },
-          {
-            "id": 5,
-            "field": "Max",
-            "title": "",
-            "isEnabled": true,
-            "rules": [
-              {
-                "id": 0,
-                "color": "#7DC540",
-                "comparator": "≥",
-                "label": "",
-                "value": 0
-              },
-              {
-                "id": 1,
-                "color": "#F5D30F",
-                "comparator": "≥",
-                "label": "",
-                "value": 2500
-              },
-              {
-                "id": 2,
-                "color": "#DC172A",
-                "comparator": "≥",
-                "label": "",
-                "value": 5000
-              }
-            ]
-          }
-        ],
-        "table": {
-          "colorThresholdTarget": "background",
-          "hideColumnsForLargeResults": true,
-          "rowDensity": "comfortable",
-          "sortBy": [{ "columnId": "[\"P99\"]", "direction": "ascending" }],
-          "selectedColumnForRowThreshold": "Min"
-        }
+        ]
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -2081,6 +1907,13 @@
       "query": "timeseries \n  latency_avg = avg(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_max = max(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  latency_min = min(cloud.aws.apigateway.latencyByAccountIdApiNameRegion),\n  by: { apiname },\n  filter: { aws.account.id == $SelectedAWSAccount }\n| filterOut apiname ~ \"-auth-gateway\" or apiname ~ \"-ipvcore-gateway\"\n| fieldsRename `API Name` = apiname\n| fieldsAdd\n  Min = arrayMin(latency_min),\n  Avg = arrayAvg(latency_avg),\n  P95 = arrayPercentile(latency_avg, 95),\n  P99 = arrayPercentile(latency_avg, 99),\n  Max = arrayMax(latency_max)\n| fields `API Name`, Min, Avg, P95, P99, Max",
       "visualization": "table",
       "visualizationSettings": {
+        "table": {
+          "colorThresholdTarget": "background",
+          "hideColumnsForLargeResults": true,
+          "rowDensity": "comfortable",
+          "sortBy": [{ "columnId": "[\"P99\"]", "direction": "ascending" }],
+          "selectedColumnForRowThreshold": "Min"
+        },
         "autoSelectVisualization": false,
         "unitsOverrides": [
           {
@@ -2133,15 +1966,7 @@
             "delimiter": false,
             "added": 1772813658329
           }
-        ],
-        "thresholds": [],
-        "table": {
-          "colorThresholdTarget": "background",
-          "hideColumnsForLargeResults": true,
-          "rowDensity": "comfortable",
-          "sortBy": [{ "columnId": "[\"P99\"]", "direction": "ascending" }],
-          "selectedColumnForRowThreshold": "Min"
-        }
+        ]
       },
       "querySettings": {
         "maxResultRecords": 1000,
@@ -2174,6 +1999,31 @@
             "added": 1773144594244
           }
         ],
+        "coloring": {
+          "colorRules": [
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#DC172A",
+              "field": "",
+              "value": null
+            },
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#F5D30F",
+              "field": "",
+              "value": 99.5
+            },
+            {
+              "colorMode": "custom-color",
+              "comparator": "≥",
+              "customColor": "#7DC540",
+              "field": "",
+              "value": 100
+            }
+          ]
+        },
         "colorModeType": {
           "color": "#DC172A",
           "customNumericColors": [


### PR DESCRIPTION
# Description:

Updated the TICF dashboard to include min, max, average, P95 and P99 metrics for the API gateway.

New panels created:
<img width="1216" height="382" alt="image" src="https://github.com/user-attachments/assets/c993ad63-914d-41df-a9d7-09359c57e1a8" />

Test dashboard - https://khw46367.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/b931ccb8-ef27-47dc-9934-463aa702f1b1#from=now%28%29-30d&to=now%28%29&tileIds=&vfilter_Environment=TICF+CRI+-+Staging+-+640259204840&vfilter_Lambda=All

## Ticket number:
[FPAD-7509]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[FPAD-7509]: https://govukverify.atlassian.net/browse/FPAD-7509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ