### PR TITLE
Bau orchestration account split

### DIFF
--- a/dashboards/orchestration/authentication.json
+++ b/dashboards/orchestration/authentication.json
@@ -1856,7 +1856,21 @@
           "sortBy": "DESC",
           "sortByDimension": "",
           "filterBy": {
-            "nestedFilters": [],
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "environment",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "production",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
             "criteria": []
           },
           "limit": 20,
@@ -1872,7 +1886,21 @@
           "sortBy": "DESC",
           "sortByDimension": "",
           "filterBy": {
-            "nestedFilters": [],
+            "filterOperator": "AND",
+            "nestedFilters": [
+              {
+                "filter": "environment",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "production",
+                    "evaluator": "EQ"
+                  }
+                ]
+              }
+            ],
             "criteria": []
           },
           "limit": 20,

--- a/dashboards/orchestration/authentication.json
+++ b/dashboards/orchestration/authentication.json
@@ -1992,7 +1992,7 @@
       ]
     },
     {
-      "name": "Total Number of Accounts (at end of peroid)",
+      "name": "Total Number of Accounts (at end of period)",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {

--- a/dashboards/orchestration/general_prod.json
+++ b/dashboards/orchestration/general_prod.json
@@ -2516,7 +2516,7 @@
           "splitBy": [
             "client"
           ],
-          "metricSelector": "(cloud.aws.authentication.userInfoReturnedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"533266965190\"))):splitBy(client):count:default(0))*100/(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"533266965190\"))):splitBy(client):count)",
+          "metricSelector": "(cloud.aws.authentication.userInfoReturnedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"058264132019\"))):splitBy(client):count:default(0))*100/(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"058264132019\"))):splitBy(client):count)",
           "rate": "NONE",
           "enabled": true
         }
@@ -2588,7 +2588,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&((cloud.aws.authentication.userInfoReturnedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"533266965190\"))):splitBy(client):count:default(0))*100/(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"533266965190\"))):splitBy(client):count)):limit(100):names"
+        "resolution=null&((cloud.aws.authentication.userInfoReturnedByAccountIdClientEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"058264132019\"))):splitBy(client):count:default(0))*100/(cloud.aws.authentication.successfulTokenIssuedByAccountIdClientClientNameEnvironmentLogGroupRegionServiceNameServiceType:filter(or(eq(\"aws.account.id\",\"533266965190\"),eq(\"aws.account.id\",\"058264132019\"))):splitBy(client):count)):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Noticed a typo in Orchestration - Authentication prod dashboard
Noticed a graph is not filtered for just production in Orchestration - Authentication prod dashboard
Noticed a graph is only filter for production (instead of production and integration) in Orchestration General dashboard

## Ticket number:
N/A minor fixes to dashboards

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


Orchestration General change screenshot:
<img width="573" height="350" alt="Screenshot 2026-04-08 at 08 41 30" src="https://github.com/user-attachments/assets/481bda04-1e24-4aa8-9292-f0af527da0e8" />


Orchestration - Authentication change (temporary graph as I'm unable to actually edit this dashboard):
<img width="505" height="354" alt="Screenshot 2026-04-08 at 08 45 29" src="https://github.com/user-attachments/assets/f49475e0-3cb1-414a-a531-45748068604e" />

