### PR TITLE
DCMAW-19643: remove grace period info message codes from mobile id check lambda dashboards

### DIFF
--- a/dashboards/id-check/async-backend-lambda.json
+++ b/dashboards/id-check/async-backend-lambda.json
@@ -7090,106 +7090,6 @@
       ]
     },
     {
-      "name": "issue-biometric-credential: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1216,
-        "left": 2736,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.mob-async-backend.logmessages.asyncIssueBiometricCredentialMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\", \"MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_COMPLETED\"), eq(\"messagecode\", \"MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_STARTED\"),eq(\"messagecode\", \"MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "C"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.mob-async-backend.logmessages.asyncIssueBiometricCredentialMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_COMPLETED),eq(messagecode,MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_STARTED),eq(messagecode,MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED)))):sum):limit(100):names"
-      ]
-    },
-    {
       "name": "token: Message Codes",
       "tileType": "DATA_EXPLORER",
       "configured": true,
@@ -7400,6 +7300,106 @@
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
       "markdown": "Left value shows number of STARTED message codes. Right value shows number of COMPLETED message codes.\n\nFor credential lambda, the third tile is the number of SESSION_CREATED message codes.\n\nFor issue-biometric-credential lambda, the third tile is the number of VC_ISSUED message codes."
+    },
+    {
+      "name": "issue-biometric-credential: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1216,
+        "left": 2736,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.mob-async-backend.logmessages.asyncIssueBiometricCredentialMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\", \"MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_COMPLETED\"), eq(\"messagecode\", \"MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_STARTED\"),eq(\"messagecode\", \"MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED\"),eq(\"messagecode\", \"MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_EXPIRY_GRACE_PERIOD\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.mob-async-backend.logmessages.asyncIssueBiometricCredentialMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_COMPLETED),eq(messagecode,MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_STARTED),eq(messagecode,MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED),eq(messagecode,MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_EXPIRY_GRACE_PERIOD)))):sum):limit(100):names"
+      ]
     }
   ]
 }

--- a/dashboards/id-check/dcmaw-backend-lambda.json
+++ b/dashboards/id-check/dcmaw-backend-lambda.json
@@ -6675,7 +6675,7 @@
           "hideLegend": false
         },
         "rules": [
-        {
+          {
             "matcher": "D:",
             "properties": {
               "color": "DEFAULT"
@@ -9346,105 +9346,6 @@
       ]
     },
     {
-      "name": "UserInfoFunction-backend: Message Codes",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 2660,
-        "left": 1824,
-        "width": 456,
-        "height": 228
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Data explorer results",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": [
-            "messagecode"
-          ],
-          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_STARTED\"), eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_COMPLETED\")))):sum",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "STACKED_COLUMN",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "STACKED_COLUMN"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "displayName": "",
-            "visible": true
-          },
-          "yAxes": [
-            {
-              "displayName": "",
-              "visible": true,
-              "min": "AUTO",
-              "max": "AUTO",
-              "position": "LEFT",
-              "queryIds": [
-                "B"
-              ],
-              "defaultAxis": true
-            }
-          ]
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": []
-        },
-        "graphChartSettings": {
-          "connectNulls": true
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_STARTED),eq(messagecode,DCMAW_FETCH_USER_INFO_V2_COMPLETED)))):sum):limit(100):names"
-      ]
-    },
-    {
       "name": "DCMAW_FETCH_USER_INFO_V2_STARTED",
       "nameSize": "small",
       "tileType": "DATA_EXPLORER",
@@ -10149,7 +10050,7 @@
               },
               {
                 "color": "#f5d30f"
-            },
+              },
               {
                 "color": "#dc172a"
               }
@@ -10159,7 +10060,7 @@
         ],
         "tableSettings": {
           "hiddenColumns": []
-          },
+        },
         "graphChartSettings": {
           "connectNulls": false
         },
@@ -10186,7 +10087,7 @@
         "left": 2280,
         "width": 228,
         "height": 228
-          },
+      },
       "tileFilter": {},
       "isAutoRefreshDisabled": false,
       "customName": "Single value",
@@ -10265,7 +10166,7 @@
         "resolution=Inf&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:sum:splitBy(messagecode):filter(eq(messagecode,DCMAW_OPENID_CONFIGURATION_STARTED))):limit(100):names"
       ]
     },
-              {
+    {
       "name": "DCMAW_OPENID_CONFIGURATION_COMPLETED",
       "nameSize": "small",
       "tileType": "DATA_EXPLORER",
@@ -10302,8 +10203,8 @@
               "color": "DEFAULT"
             },
             "seriesOverrides": []
-              }
-            ],
+          }
+        ],
         "axes": {
           "xAxis": {
             "visible": true
@@ -10451,6 +10352,105 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.backend-api.logmessages.openidConfigurationMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_OPENID_CONFIGURATION_STARTED),eq(messagecode,DCMAW_OPENID_CONFIGURATION_COMPLETED)))):sum):limit(100):names"
+      ]
+    },
+    {
+      "name": "UserInfoFunction-backend: Message Codes",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2660,
+        "left": 1824,
+        "width": 456,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "messagecode"
+          ],
+          "metricSelector": "cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(\"messagecode\"):filter(not(or(eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_STARTED\"), eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_COMPLETED\"), eq(\"messagecode\",\"DCMAW_FETCH_USER_INFO_V2_DRIVING_LICENCE_DVLA_GRACE_PERIOD_VALUE\")))):sum",
+          "rate": "NONE",
+          "enabled": true
+        }
+      ],
+      "visualConfig": {
+        "type": "STACKED_COLUMN",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "STACKED_COLUMN"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.backend-api.logmessages.userInfoMessageCodeByAccountIdMessageCodeRegionVersion:splitBy(messagecode):filter(not(or(eq(messagecode,DCMAW_FETCH_USER_INFO_V2_STARTED),eq(messagecode,DCMAW_FETCH_USER_INFO_V2_COMPLETED),eq(messagecode,DCMAW_FETCH_USER_INFO_V2_DRIVING_LICENCE_DVLA_GRACE_PERIOD_VALUE)))):sum):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:
Removes noisy info message codes from a tile in mobile id checks lambda dashboards.

Dashboard: MOBILE - DCMAW BE - Lambda
Tile: UserInfoFunction-backend: Message Codes
Code to be removed: `DCMAW_FETCH_USER_INFO_V2_DRIVING_LICENCE_DVLA_GRACE_PERIOD_VALUE` 

Dashboard: MOBILE - ID CHECK ASYNC BE - Lambda
Tile: issue-biometric-credential: Message Codes
Code to be removed: `MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_EXPIRY_GRACE_PERIOD` 

## Ticket number:
[DCMAW-19643]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:

Async
<img width="3232" height="1261" alt="Screenshot 2026-04-08 at 13 50 58" src="https://github.com/user-attachments/assets/85c477af-2ab1-4319-93cb-e4c5c96beb6b" />

DCMAW
<img width="3229" height="1139" alt="Screenshot 2026-04-08 at 13 52 23" src="https://github.com/user-attachments/assets/e87a63b8-3a07-4951-b0b6-260e75b91e68" />

[DCMAW-19643]: https://govukverify.atlassian.net/browse/DCMAW-19643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ