### PR TITLE
Make observability code owners instead of FOG

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/fog @govuk-one-login/digital-identity-leads
+* @govuk-one-login/observability @govuk-one-login/digital-identity-leads


### PR DESCRIPTION
The observability team takes over Dynatrace BAU responsibilities from the FOG team. We have a work item to transfer code ownership: https://govukverify.atlassian.net/browse/PSREOBS-255

