### PR TITLE
Reduce the RUM sampling rate for Authentication and IPV-Core frontends

### DIFF
--- a/web_applications.tf
+++ b/web_applications.tf
@@ -3,7 +3,7 @@ locals {
     signin = {
       hostname                = "signin"
       name                    = "Authentication"
-      user_session_percentage = 50
+      user_session_percentage = 10
       injection_rule          = "AUTOMATIC_INJECTION"
       injection_operator      = "ALL_PAGES"
     },
@@ -17,7 +17,7 @@ locals {
     identity = {
       hostname                = "identity"
       name                    = "IPV Core"
-      user_session_percentage = 50
+      user_session_percentage = 25
       injection_rule          = "DO_NOT_INJECT"
       injection_operator      = "ALL_PAGES"
     },


### PR DESCRIPTION
At the current sampling rate of 50 percent, we are monitoring ca. 500 and 200 user journeys peak for the Authentication and IPV-Core frontends, respectively. 
This is incurring significant cost and will grow linearly with RP onboarding.

TSD have agreed to reduce the peak recorded journeys to about 100.

The work item is here: https://govukverify.atlassian.net/browse/PSREOBS-233

# Description:

## Ticket number:
[PSREOBS-233]

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[PSREOBS-233]: https://govukverify.atlassian.net/browse/PSREOBS-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ