### PR TITLE
SPT-1906: Adds CI age to table

### DIFF
--- a/dashboards/spot/cimit-ci-metrics.json
+++ b/dashboards/spot/cimit-ci-metrics.json
@@ -1,7 +1,9 @@
 {
   "metadata": {
-    "configurationVersions": [7],
-    "clusterVersion": "1.334.31.20260305-231837"
+    "configurationVersions": [
+      7
+    ],
+    "clusterVersion": "1.338.43.20260501-091025"
   },
   "dashboardMetadata": {
     "name": "CIMIT CI and Mitigations metrics",
@@ -33,7 +35,8 @@
           "splitBy": [],
           "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy():sum()",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -185,10 +188,13 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["ci"],
+          "splitBy": [
+            "ci"
+          ],
           "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum():sort(dimension(\"ci\", ascending))",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -272,7 +278,8 @@
           "splitBy": [],
           "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy():sum()",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -359,10 +366,13 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["ci"],
+          "splitBy": [
+            "ci"
+          ],
           "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(\"ci\"):sum():sort(dimension(\"ci\", ascending))",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -449,10 +459,13 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["ci"],
+          "splitBy": [
+            "ci"
+          ],
           "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum():sort(dimension(\"ci\", ascending))",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -481,7 +494,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -544,10 +559,13 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["ci"],
+          "splitBy": [
+            "ci"
+          ],
           "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(\"ci\"):sum():sort(dimension(\"ci\", ascending))",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -577,7 +595,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -645,10 +665,14 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["ci", "mitigation"],
+          "splitBy": [
+            "ci",
+            "mitigation"
+          ],
           "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(\"ci\", \"mitigation\"):sum():sort(dimension(\"ci\", ascending), dimension(\"mitigation\", ascending))",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -678,7 +702,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -746,10 +772,14 @@
           "id": "A",
           "spaceAggregation": "AUTO",
           "timeAggregation": "DEFAULT",
-          "splitBy": ["ci", "mitigation"],
+          "splitBy": [
+            "ci",
+            "mitigation"
+          ],
           "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(\"ci\", \"mitigation\"):sum():sort(dimension(\"ci\", ascending), dimension(\"mitigation\", ascending))",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -844,7 +874,8 @@
           "splitBy": [],
           "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy():sum()",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -877,7 +908,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -943,7 +976,8 @@
           "splitBy": [],
           "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy():sum()",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -976,7 +1010,9 @@
               "min": "AUTO",
               "max": "AUTO",
               "position": "LEFT",
-              "queryIds": ["A"],
+              "queryIds": [
+                "A"
+              ],
               "defaultAxis": true
             }
           ]
@@ -1021,132 +1057,6 @@
       ]
     },
     {
-      "name": "",
-      "tileType": "DATA_EXPLORER",
-      "configured": true,
-      "bounds": {
-        "top": 1520,
-        "left": 0,
-        "width": 988,
-        "height": 456
-      },
-      "tileFilter": {},
-      "isAutoRefreshDisabled": false,
-      "customName": "Table",
-      "queries": [
-        {
-          "id": "B",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": ["ci"],
-          "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum():sort(dimension(\"ci\", ascending))",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "C",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": ["ci"],
-          "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(\"ci\"):sum():default(0)",
-          "rate": "NONE",
-          "enabled": true
-        },
-        {
-          "id": "A",
-          "spaceAggregation": "AUTO",
-          "timeAggregation": "DEFAULT",
-          "splitBy": ["ci"],
-          "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum():default(0)-\ncloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(\"ci\"):sum():default(0)",
-          "rate": "NONE",
-          "enabled": true
-        }
-      ],
-      "visualConfig": {
-        "type": "TABLE",
-        "global": {},
-        "rules": [
-          {
-            "matcher": "B:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "CIs Detected"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "C:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "CIs Mitigated"
-            },
-            "seriesOverrides": []
-          },
-          {
-            "matcher": "A:",
-            "unitTransform": "auto",
-            "valueFormat": "auto",
-            "properties": {
-              "color": "DEFAULT",
-              "seriesType": "LINE",
-              "alias": "Not Mitigated CIs"
-            },
-            "seriesOverrides": []
-          }
-        ],
-        "axes": {
-          "xAxis": {
-            "visible": true
-          },
-          "yAxes": []
-        },
-        "heatmapSettings": {
-          "yAxis": "VALUE"
-        },
-        "thresholds": [
-          {
-            "axisTarget": "LEFT",
-            "rules": [
-              {
-                "color": "#7dc540"
-              },
-              {
-                "color": "#f5d30f"
-              },
-              {
-                "color": "#dc172a"
-              }
-            ],
-            "queryId": "A",
-            "visible": true
-          }
-        ],
-        "tableSettings": {
-          "hiddenColumns": ["A:ci.name", "B:ci.name", "C:ci.name"]
-        },
-        "graphChartSettings": {
-          "connectNulls": false
-        },
-        "honeycombSettings": {
-          "showHive": true,
-          "showLegend": true,
-          "showLabels": false
-        }
-      },
-      "queriesSettings": {
-        "resolution": ""
-      },
-      "metricExpressions": [
-        "resolution=null&(cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum:sort(dimension(ci,ascending))):names:fold(auto),(cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(ci):sum:default(0)):names:fold(auto),(cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum:default(0)-cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(ci):sum:default(0)):names:fold(auto)"
-      ]
-    },
-    {
       "name": "Total CIs",
       "nameSize": "small",
       "tileType": "DATA_EXPLORER",
@@ -1175,7 +1085,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1269,7 +1180,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1356,7 +1268,8 @@
           "splitBy": [],
           "metricSelector": "cloud.aws.cimit.securityCredentialsCreatedByAccountIdNumberOfContraIndicatorsNumberOfContraIndicatorsMitigatedRegionservice:splitBy():sum()",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1454,7 +1367,8 @@
           ],
           "metricSelector": "(cloud.aws.cimit.numberOfStoredMitigationsByAccountIdRegionservice/cloud.aws.cimit.numberOfStoredContraIndicatorsByAccountIdRegionservice)*100",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1521,6 +1435,193 @@
       },
       "metricExpressions": [
         "resolution=Inf&((cloud.aws.cimit.numberOfStoredMitigationsByAccountIdRegionservice/cloud.aws.cimit.numberOfStoredContraIndicatorsByAccountIdRegionservice)*100):limit(100):names"
+      ]
+    },
+    {
+      "name": "",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1520,
+        "left": 0,
+        "width": 988,
+        "height": 456
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Table",
+      "queries": [
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "ci"
+          ],
+          "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum():sort(dimension(\"ci\", ascending))",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "ci"
+          ],
+          "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(\"ci\"):sum():default(0)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "ci"
+          ],
+          "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedCiAgeByAccountIdRegioncimitigationservice:splitBy(\"ci\"):count():partition(\"age\",value(\"lt_2h\",lt(7200))):filter(eq(\"age\",\"lt_2h\")):splitBy(\"ci\"):sum():default(0,always)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "E",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "ci"
+          ],
+          "metricSelector": "cloud.aws.cimit.mitigationRuleMatchedCiAgeByAccountIdRegioncimitigationservice:splitBy(\"ci\"):count():partition(\"age\",value(\"gte_2h\",ge(7200))):filter(eq(\"age\",\"gte_2h\")):splitBy(\"ci\"):sum():default(0,always)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [
+            "ci"
+          ],
+          "metricSelector": "cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum():default(0)-cloud.aws.cimit.mitigationRuleMatchedCiAgeByAccountIdRegioncimitigationservice:splitBy(\"ci\"):count():partition(\"age\",value(\"lt_2h\",lt(7200))):filter(eq(\"age\",\"lt_2h\")):splitBy(\"ci\"):sum():default(0,always)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "TABLE",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "CIs Detected"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "CIs Mitigated (all)"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "CIs Mitigated < 2h"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "E:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "CIs Mitigated >= 2h"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE",
+              "alias": "Not Mitigated CIs < 2h"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": [
+            "A:ci.name",
+            "B:ci.name",
+            "C:ci.name",
+            "D:ci.name",
+            "E:ci.name"
+          ]
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum:sort(dimension(ci,ascending))):names:fold(auto),(cloud.aws.cimit.mitigationRuleMatchedByAccountIdRegioncimitigationservice:splitBy(ci):sum:default(0)):names:fold(auto),(cloud.aws.cimit.mitigationRuleMatchedCiAgeByAccountIdRegioncimitigationservice:splitBy(ci):count:partition(age,value(lt_2h,lt(7200))):filter(eq(age,lt_2h)):splitBy(ci):sum:default(0,always)):names:fold(auto),(cloud.aws.cimit.mitigationRuleMatchedCiAgeByAccountIdRegioncimitigationservice:splitBy(ci):count:partition(age,value(gte_2h,ge(7200))):filter(eq(age,gte_2h)):splitBy(ci):sum:default(0,always)):names:fold(auto),(cloud.aws.cimit.contraIndicatorDetectedByAccountIdIssuerRegionciservice:splitBy(ci):sum:default(0)-cloud.aws.cimit.mitigationRuleMatchedCiAgeByAccountIdRegioncimitigationservice:splitBy(ci):count:partition(age,value(lt_2h,lt(7200))):filter(eq(age,lt_2h)):splitBy(ci):sum:default(0,always)):names:fold(auto)"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Adds two new columns to the CIMIT comparison table:

- CIs Mitigated < 2h (new mitigations)
- CIs Mitigated >= 2h (historic mitigations)

Also, updates the 'Not Mitigated CIs' calculation to only subtract < 2h mitigations.

To get this JSON, I edited a cloned CIMIT dashboard on dynatrace, and then removed the `id` field.

## Ticket number:
[SPT-1906]

## Checklist:
- [x] Is my change backwards compatible? - This edits an existing table in accordance with the ticket
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:

[SPT-1906]: https://govukverify.atlassian.net/browse/SPT-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ