### PR TITLE
BAU: Update PERF006 stats for new TPS definition

### DIFF
--- a/dashboards/orange/accountmanagement-slas-Orange.json
+++ b/dashboards/orange/accountmanagement-slas-Orange.json
@@ -3,7 +3,7 @@
     "configurationVersions": [
       7
     ],
-    "clusterVersion": "1.336.38.20260406-092212"
+    "clusterVersion": "1.340.46.20260609-124236"
   },
   "dashboardMetadata": {
     "name": "Orange Account Management SLAs",
@@ -73,8 +73,8 @@
       "configured": true,
       "bounds": {
         "top": 1368,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -172,8 +172,8 @@
       "configured": true,
       "bounds": {
         "top": 1482,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -271,8 +271,8 @@
       "configured": true,
       "bounds": {
         "top": 1596,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -791,7 +791,7 @@
       "bounds": {
         "top": 1368,
         "left": 0,
-        "width": 418,
+        "width": 684,
         "height": 114
       },
       "tileFilter": {},
@@ -886,7 +886,7 @@
       "bounds": {
         "top": 38,
         "left": 0,
-        "width": 418,
+        "width": 684,
         "height": 114
       },
       "tileFilter": {},
@@ -980,8 +980,8 @@
       "configured": true,
       "bounds": {
         "top": 38,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -1079,8 +1079,8 @@
       "configured": true,
       "bounds": {
         "top": 152,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -1178,8 +1178,8 @@
       "configured": true,
       "bounds": {
         "top": 266,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -1698,7 +1698,7 @@
       "bounds": {
         "top": 2698,
         "left": 0,
-        "width": 418,
+        "width": 684,
         "height": 114
       },
       "tileFilter": {},
@@ -1792,8 +1792,8 @@
       "configured": true,
       "bounds": {
         "top": 2698,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -1891,8 +1891,8 @@
       "configured": true,
       "bounds": {
         "top": 2812,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -1990,8 +1990,8 @@
       "configured": true,
       "bounds": {
         "top": 2926,
-        "left": 418,
-        "width": 418,
+        "left": 684,
+        "width": 190,
         "height": 114
       },
       "tileFilter": {},
@@ -2282,11 +2282,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "check-hmrc-cri-api-public",
+                    "value": "check-hmrc-cri-api-private",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "check-hmrc-cri-api-private",
+                    "value": "check-hmrc-cri-api-public",
                     "evaluator": "EQ"
                   }
                 ]
@@ -2317,11 +2317,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "check-hmrc-cri-api-private",
+                    "value": "check-hmrc-cri-api-public",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "check-hmrc-cri-api-public",
+                    "value": "check-hmrc-cri-api-private",
                     "evaluator": "EQ"
                   }
                 ]
@@ -2471,7 +2471,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,check-hmrc-cri-api-private),eq(apiname,check-hmrc-cri-api-public)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,check-hmrc-cri-api-private),eq(apiname,check-hmrc-cri-api-public)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,check-hmrc-cri-api-private),eq(apiname,check-hmrc-cri-api-public)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,check-hmrc-cri-api-public),eq(apiname,check-hmrc-cri-api-private)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,check-hmrc-cri-api-public),eq(apiname,check-hmrc-cri-api-private)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,check-hmrc-cri-api-public),eq(apiname,check-hmrc-cri-api-private)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -2751,27 +2751,27 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "aws.account.id",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": []
-              },
-              {
                 "filter": "apiname",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "kbv-cri-kbv-cri-api-v1",
+                    "value": "kbv-cri-private-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "kbv-cri-private-kbv-cri-api-v1",
+                    "value": "kbv-cri-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   }
                 ]
+              },
+              {
+                "filter": "aws.account.id",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": []
               }
             ],
             "criteria": []
@@ -2841,11 +2841,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "kbv-cri-private-kbv-cri-api-v1",
+                    "value": "kbv-cri-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "kbv-cri-kbv-cri-api-v1",
+                    "value": "kbv-cri-private-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   }
                 ]
@@ -2969,7 +2969,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,kbv-cri-kbv-cri-api-v1),eq(apiname,kbv-cri-private-kbv-cri-api-v1)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,kbv-cri-kbv-cri-api-v1),eq(apiname,kbv-cri-private-kbv-cri-api-v1)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,kbv-cri-kbv-cri-api-v1),eq(apiname,kbv-cri-private-kbv-cri-api-v1)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,kbv-cri-private-kbv-cri-api-v1),eq(apiname,kbv-cri-kbv-cri-api-v1)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,kbv-cri-private-kbv-cri-api-v1),eq(apiname,kbv-cri-kbv-cri-api-v1)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.apigateway.latencyByAccountIdApiNameMethodRegionResourceStage:filter(and(or(eq(apiname,kbv-cri-private-kbv-cri-api-v1),eq(apiname,kbv-cri-kbv-cri-api-v1)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -3601,8 +3601,8 @@
       "configured": true,
       "bounds": {
         "top": 1482,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -3698,8 +3698,8 @@
       "configured": true,
       "bounds": {
         "top": 1368,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -3795,8 +3795,8 @@
       "configured": true,
       "bounds": {
         "top": 2812,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -3892,8 +3892,8 @@
       "configured": true,
       "bounds": {
         "top": 2926,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -3989,8 +3989,8 @@
       "configured": true,
       "bounds": {
         "top": 2698,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -4086,8 +4086,8 @@
       "configured": true,
       "bounds": {
         "top": 152,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -4183,8 +4183,8 @@
       "configured": true,
       "bounds": {
         "top": 266,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -4280,8 +4280,8 @@
       "configured": true,
       "bounds": {
         "top": 38,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -5088,13 +5088,13 @@
       ]
     },
     {
-      "name": "PERF006 - Average transaction rate",
+      "name": "Avg transaction rate (old; FE)",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 1482,
         "left": 0,
-        "width": 418,
+        "width": 342,
         "height": 114
       },
       "tileFilter": {},
@@ -5187,13 +5187,13 @@
       ]
     },
     {
-      "name": "PERF006 - Peak transaction rate",
+      "name": "Peak transaction rate (old; FE)",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 1596,
         "left": 0,
-        "width": 418,
+        "width": 342,
         "height": 114
       },
       "tileFilter": {},
@@ -5286,13 +5286,13 @@
       ]
     },
     {
-      "name": "PERF006 - Average transaction rate",
+      "name": "Avg transaction rate (old; FE)",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 152,
         "left": 0,
-        "width": 418,
+        "width": 342,
         "height": 114
       },
       "tileFilter": {},
@@ -5385,13 +5385,13 @@
       ]
     },
     {
-      "name": "PERF006 - Peak transaction rate",
+      "name": "Peak transaction rate (old; FE)",
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
         "top": 266,
         "left": 0,
-        "width": 418,
+        "width": 342,
         "height": 114
       },
       "tileFilter": {},
@@ -5490,7 +5490,7 @@
       "bounds": {
         "top": 2812,
         "left": 0,
-        "width": 418,
+        "width": 342,
         "height": 114
       },
       "tileFilter": {},
@@ -5589,7 +5589,7 @@
       "bounds": {
         "top": 2926,
         "left": 0,
-        "width": 418,
+        "width": 342,
         "height": 114
       },
       "tileFilter": {},
@@ -5687,8 +5687,8 @@
       "configured": true,
       "bounds": {
         "top": 1596,
-        "left": 836,
-        "width": 418,
+        "left": 874,
+        "width": 380,
         "height": 114
       },
       "tileFilter": {},
@@ -6943,7 +6943,24 @@
           },
           "yAxes": []
         },
-        "thresholds": []
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "thresholds": [],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
       },
       "metricExpressions": []
     },
@@ -7406,6 +7423,802 @@
       "metricExpressions": [
         "resolution=1h&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:splitBy():count:rate(1s):setUnit(PerSecond)):limit(100):names:fold(max)",
         "resolution=1h&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:splitBy():count:rate(1s):setUnit(PerSecond))"
+      ]
+    },
+    {
+      "name": "PERF006 - Peak transaction rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 266,
+        "left": 342,
+        "width": 342,
+        "height": 114
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"address-cri-api-v1-PrivateAddressApi\"),eq(apiname,\"address-cri-api-v1-PublicAddressApi\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "(\nbuiltin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s)\n  +\ncloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"address-cri-api-v1-PrivateAddressApi\"),eq(apiname,\"address-cri-api-v1-PublicAddressApi\"))):splitBy():sum:rate(1s)\n):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "BLUE",
+              "seriesType": "LINE",
+              "alias": "average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 100000,
+                "color": "#7dc540"
+              },
+              {
+                "value": 10000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": false
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi))):splitBy():sum:rate(1s)):setUnit(PerSecond)):limit(100):names:fold(max)",
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi))):splitBy():sum:rate(1s)):setUnit(PerSecond))"
+      ]
+    },
+    {
+      "name": "PERF006 - Avg transaction rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 152,
+        "left": 342,
+        "width": 342,
+        "height": 114
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"address-cri-api-v1-PrivateAddressApi\"),eq(apiname,\"address-cri-api-v1-PublicAddressApi\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "(\nbuiltin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s)\n  +\ncloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"address-cri-api-v1-PrivateAddressApi\"),eq(apiname,\"address-cri-api-v1-PublicAddressApi\"))):splitBy():sum:rate(1s)\n):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 100000,
+                "color": "#7dc540"
+              },
+              {
+                "value": 10000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": false
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "AVG"
+      },
+      "metricExpressions": [
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi))):splitBy():sum:rate(1s)):setUnit(PerSecond)):limit(100):names:fold(avg)",
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Address CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,address-cri-api-v1-PrivateAddressApi),eq(apiname,address-cri-api-v1-PublicAddressApi))):splitBy():sum:rate(1s)):setUnit(PerSecond))"
+      ]
+    },
+    {
+      "name": "PERF006 - Avg transaction rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1482,
+        "left": 342,
+        "width": 342,
+        "height": 114
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"kbv-cri-private-kbv-cri-api-v1\"),eq(apiname,\"kbv-cri-kbv-cri-api-v1\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "(\nbuiltin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s)\n  +\ncloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"kbv-cri-private-kbv-cri-api-v1\"),eq(apiname,\"kbv-cri-kbv-cri-api-v1\"))):splitBy():sum:rate(1s)\n):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 100000,
+                "color": "#7dc540"
+              },
+              {
+                "value": 10000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": false
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "AVG"
+      },
+      "metricExpressions": [
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,kbv-cri-private-kbv-cri-api-v1),eq(apiname,kbv-cri-kbv-cri-api-v1))):splitBy():sum:rate(1s)):setUnit(PerSecond)):limit(100):names:fold(avg)",
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,kbv-cri-private-kbv-cri-api-v1),eq(apiname,kbv-cri-kbv-cri-api-v1))):splitBy():sum:rate(1s)):setUnit(PerSecond))"
+      ]
+    },
+    {
+      "name": "PERF006 - Peak transaction rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1596,
+        "left": 342,
+        "width": 342,
+        "height": 114
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"kbv-cri-private-kbv-cri-api-v1\"),eq(apiname,\"kbv-cri-kbv-cri-api-v1\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "(\nbuiltin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s)\n  +\ncloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"kbv-cri-private-kbv-cri-api-v1\"),eq(apiname,\"kbv-cri-kbv-cri-api-v1\"))):splitBy():sum:rate(1s)\n):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 100000,
+                "color": "#7dc540"
+              },
+              {
+                "value": 10000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": false
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,kbv-cri-private-kbv-cri-api-v1),eq(apiname,kbv-cri-kbv-cri-api-v1))):splitBy():sum:rate(1s)):setUnit(PerSecond)):limit(100):names:fold(max)",
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"Experian KBV CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,kbv-cri-private-kbv-cri-api-v1),eq(apiname,kbv-cri-kbv-cri-api-v1))):splitBy():sum:rate(1s)):setUnit(PerSecond))"
+      ]
+    },
+    {
+      "name": "PERF006 - Avg transaction rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2812,
+        "left": 342,
+        "width": 342,
+        "height": 114
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"check-hmrc-cri-api-private\"),eq(apiname,\"check-hmrc-cri-api-public\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "(\nbuiltin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s)\n  +\ncloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"check-hmrc-cri-api-private\"),eq(apiname,\"check-hmrc-cri-api-public\"))):splitBy():sum:rate(1s)\n):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 100000,
+                "color": "#7dc540"
+              },
+              {
+                "value": 10000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": false
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "AVG"
+      },
+      "metricExpressions": [
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,check-hmrc-cri-api-private),eq(apiname,check-hmrc-cri-api-public))):splitBy():sum:rate(1s)):setUnit(PerSecond)):limit(100):names:fold(avg)",
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,check-hmrc-cri-api-private),eq(apiname,check-hmrc-cri-api-public))):splitBy():sum:rate(1s)):setUnit(PerSecond))"
+      ]
+    },
+    {
+      "name": "PERF006 - Avg transaction rate",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 2926,
+        "left": 342,
+        "width": 342,
+        "height": 114
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"check-hmrc-cri-api-private\"),eq(apiname,\"check-hmrc-cri-api-public\"))):splitBy():sum:rate(1s):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": false,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "(\nbuiltin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s)\n  +\ncloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,\"check-hmrc-cri-api-private\"),eq(apiname,\"check-hmrc-cri-api-public\"))):splitBy():sum:rate(1s)\n):setUnit(PerSecond)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "SINGLE_VALUE",
+        "global": {
+          "hideLegend": false
+        },
+        "rules": [
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "DEFAULT",
+              "seriesType": "LINE"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "visible": true
+          },
+          "yAxes": []
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE"
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "value": 100000,
+                "color": "#7dc540"
+              },
+              {
+                "value": 10000,
+                "color": "#f5d30f"
+              },
+              {
+                "value": 1,
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "",
+            "visible": false
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": "",
+        "foldTransformation": "TOTAL",
+        "foldAggregation": "MAX"
+      },
+      "metricExpressions": [
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,check-hmrc-cri-api-private),eq(apiname,check-hmrc-cri-api-public))):splitBy():sum:rate(1s)):setUnit(PerSecond)):limit(100):names:fold(max)",
+        "resolution=null&((builtin:apps.web.actionCount.load.browser:filter(in(\"dt.entity.application\",entitySelector(\"type(application),entityName.equals(~\"HMRC NINO Check CRI Production~\")\"))):splitBy():sum:rate(1s)+cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(or(eq(apiname,check-hmrc-cri-api-private),eq(apiname,check-hmrc-cri-api-public))):splitBy():sum:rate(1s)):setUnit(PerSecond))"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

TPS now means all page loads and API requests. Previously we were using frontend request count. The numbers seem to generally be lower, despite the addition of API stats. I suspect this is because the majority of FE requests don't get reported back as page loads, probably due to bots and browser privacy features.

This change just adds new panels to the reports and renames existing panels to reflect the fact that they are reporting on old metrics.

The dashboard used for development can be found [here](https://bhe21058.live.dynatrace.com/#dashboard;id=974197b6-6cf4-447d-a886-33f210a6dabf) and will be cleaned up once merged.

## Representative screenshots

### Before

<img width="1262" height="427" alt="image" src="https://github.com/user-attachments/assets/89f5770d-c0d2-4575-96df-2cc168a1a715" />


### After

<img width="1271" height="424" alt="image" src="https://github.com/user-attachments/assets/79ebe1e9-6e3c-462f-8fb6-a6935da9e165" />


## Ticket number:

- N/A

## Checklist:

- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [x] Documentation added (link) Comment:
