### PR TITLE
ATO-2704:  add migration dashboards

### DIFF
--- a/dashboards/orchestration/cloudfront_migration_non_prod.json
+++ b/dashboards/orchestration/cloudfront_migration_non_prod.json
@@ -141,8 +141,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2204,
-          "left": 760,
+          "top": 76,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -238,8 +238,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2204,
-          "left": 0,
+          "top": 76,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -538,8 +538,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2736,
-          "left": 0,
+          "top": 608,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -633,8 +633,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2736,
-          "left": 760,
+          "top": 608,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -728,8 +728,8 @@
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 2698,
-          "left": 0,
+          "top": 570,
+          "left": 1558,
           "width": 1520,
           "height": 38
         },
@@ -1003,7 +1003,7 @@
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 1596,
+          "top": 2128,
           "left": 0,
           "width": 1520,
           "height": 38
@@ -1016,7 +1016,7 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 1634,
+          "top": 2166,
           "left": 0,
           "width": 760,
           "height": 494
@@ -1122,7 +1122,7 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 1634,
+          "top": 2166,
           "left": 760,
           "width": 760,
           "height": 494
@@ -1228,8 +1228,8 @@
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 2128,
-          "left": 0,
+          "top": 0,
+          "left": 1558,
           "width": 1520,
           "height": 38
         },
@@ -1241,8 +1241,8 @@
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 2166,
-          "left": 0,
+          "top": 38,
+          "left": 1558,
           "width": 1520,
           "height": 38
         },
@@ -1254,8 +1254,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3230,
-          "left": 760,
+          "top": 1102,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -1385,8 +1385,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3230,
-          "left": 0,
+          "top": 1102,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -1516,8 +1516,8 @@
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 3724,
-          "left": 0,
+          "top": 2128,
+          "left": 1558,
           "width": 1520,
           "height": 38
         },
@@ -1529,8 +1529,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3762,
-          "left": 0,
+          "top": 2166,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -1624,8 +1624,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3762,
-          "left": 760,
+          "top": 2166,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -1810,6 +1810,442 @@
         "metricExpressions": [
           "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,build-orchestration-oidc-api))):splitBy(resource):sum):limit(100):names"
         ]
+      },
+      {
+        "name": "OIDC WAF",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 1596,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old OIDC WAF Blocked Request Count by Rule",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"761723964695\"), contains(\"webacl\", \"OIDC-Build\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              },
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "RIGHT",
+                "queryIds": [
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"761723964695\"),contains(webacl,OIDC-Build))):splitBy(labelname):count):limit(100):names"
+        ]
+      },
+      {
+        "name": "New OIDC WAF Blocked Request Count by Rule Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"767397776536\"), contains(\"webacl\", \"OIDC\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              },
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "RIGHT",
+                "queryIds": [
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"767397776536\"),contains(webacl,OIDC))):splitBy(labelname):count):limit(100):names"
+        ]
+      },
+      {
+        "name": "OIDC WAF",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 1596,
+          "left": 1558,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old OIDC WAF Blocked Request Count by Rule",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 1558,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"758531536632\"), contains(\"webacl\", \"OIDC\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"758531536632\"),contains(webacl,OIDC))):splitBy(labelname):count):limit(100):names"
+        ]
+      },
+      {
+        "name": "New OIDC WAF Blocked Request Count by Rule Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 2318,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"590183975515\"), contains(\"webacl\", \"OIDC\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"590183975515\"),contains(webacl,OIDC))):splitBy(labelname):count):limit(100):names"
+        ]
       }
     ]
-  }
+}

--- a/dashboards/orchestration/cloudfront_migration_non_prod.json
+++ b/dashboards/orchestration/cloudfront_migration_non_prod.json
@@ -1,0 +1,1816 @@
+{
+    "metadata": {
+      "configurationVersions": [
+        7
+      ],
+      "clusterVersion": "1.341.59.20260630-211352"
+    },
+    "id": "4b10f58b-b758-44db-933e-7edb72216049",
+    "dashboardMetadata": {
+      "name": "orchestration-cloudfront-migration-monitoring",
+      "shared": true,
+      "owner": "ryan.andrews@digital.cabinet-office.gov.uk",
+      "popularity": 10,
+      "hasConsistentColors": false
+    },
+    "tiles": [
+      {
+        "name": "API Gateway",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 38,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 76,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"aws.account.id\", \"761723964695\"), eq(\"apiname\", \"build-di-authentication-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"aws.account.id\",\"761723964695\"),eq(apiname,build-di-authentication-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "Build",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 0,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "New API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2204,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\", \"staging-orchestration-oidc-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,staging-orchestration-oidc-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2204,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\", \"staging-di-authentication-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,staging-di-authentication-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "Cloudfront",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 570,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 608,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"distributionid\",\"E1LR7Q8TNM63QV\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(distributionid,E1LR7Q8TNM63QV))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 608,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(\"distributionid\",\"E1Y9USKKKLIQMA\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(distributionid,E1Y9USKKKLIQMA))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2736,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(\"distributionid\",\"E1ULCVNG0ES8DC\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(distributionid,E1ULCVNG0ES8DC))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2736,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"590183975515\")),eq(\"distributionid\",\"EQP7H7MNHRVB6\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"590183975515\")),eq(distributionid,EQP7H7MNHRVB6))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Cloudfront",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 2698,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1102,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"distributionid\",\"E1LR7Q8TNM63QV\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"distributionid\",\"E1LR7Q8TNM63QV\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(distributionid,E1LR7Q8TNM63QV)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(distributionid,E1LR7Q8TNM63QV)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1102,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(\"distributionid\",\"E1Y9USKKKLIQMA\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(\"distributionid\",\"E1Y9USKKKLIQMA\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(distributionid,E1Y9USKKKLIQMA)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(distributionid,E1Y9USKKKLIQMA)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Route 53",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 1596,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"hostedzoneid\",\"Z062899930H8VN1UJ9CDX\"))):splitby():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              },
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "RIGHT",
+                "queryIds": [
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(hostedzoneid,Z062899930H8VN1UJ9CDX))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\", \"767397776536\"), eq(\"hostedzoneid\", \"Z10153513B1NLWHFQ9WTW\"))):splitBy():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              },
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "RIGHT",
+                "queryIds": [
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\",\"767397776536\"),eq(hostedzoneid,Z10153513B1NLWHFQ9WTW))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "Staging",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 2128,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "API Gateway",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 2166,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "New Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3230,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(\"distributionid\",\"E1Y9USKKKLIQMA\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(\"distributionid\",\"E1Y9USKKKLIQMA\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(distributionid,E1Y9USKKKLIQMA)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"767397776536\")),eq(distributionid,E1Y9USKKKLIQMA)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3230,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(\"distributionid\",\"E1ULCVNG0ES8DC\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(\"distributionid\",\"E1ULCVNG0ES8DC\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(distributionid,E1ULCVNG0ES8DC)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(distributionid,E1ULCVNG0ES8DC)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Route 53",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 3724,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3762,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(\"hostedzoneid\",\"Z013545810R9Q9A5U2JW5\"))):splitby():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"758531536632\")),eq(hostedzoneid,Z013545810R9Q9A5U2JW5))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3762,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\", \"767397776536\"), eq(\"hostedzoneid\", \"TODO\"))):splitBy():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\",\"767397776536\"),eq(hostedzoneid,TODO))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 76,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\", \"build-orchestration-oidc-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,build-orchestration-oidc-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      }
+    ]
+  }

--- a/dashboards/orchestration/cloudfront_migration_non_prod.json
+++ b/dashboards/orchestration/cloudfront_migration_non_prod.json
@@ -5,7 +5,6 @@
       ],
       "clusterVersion": "1.341.59.20260630-211352"
     },
-    "id": "4b10f58b-b758-44db-933e-7edb72216049",
     "dashboardMetadata": {
       "name": "orchestration-cloudfront-migration-monitoring",
       "shared": true,

--- a/dashboards/orchestration/cloudfront_migration_prod.json
+++ b/dashboards/orchestration/cloudfront_migration_prod.json
@@ -1,0 +1,1793 @@
+  {
+    "metadata": {
+      "configurationVersions": [
+        7
+      ],
+      "clusterVersion": "1.341.59.20260630-211352"
+    },
+    "id": "a34783ee-a7f1-4a3e-bd19-099ff989e133",
+    "dashboardMetadata": {
+      "name": "orchestration-cloudfront-migration-monitoring",
+      "shared": true,
+      "owner": "ryan.andrews@digital.cabinet-office.gov.uk",
+      "hasConsistentColors": false
+    },
+    "tiles": [
+      {
+        "name": "API Gateway",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 38,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Integration",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 0,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Cloudfront",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 570,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Cloudfront",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 2698,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Route 53",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 1596,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Production",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 2128,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "API Gateway",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 2166,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Route 53",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 3724,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 76,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"aws.account.id\", \"761723964695\"), eq(\"apiname\", \"integration-di-authentication-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"aws.account.id\",\"761723964695\"),eq(apiname,integration-di-authentication-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 76,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\", \"integration-orchestration-oidc-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,integration-orchestration-oidc-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 608,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"distributionid\",\"E26KHUPDNH7E2X\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(distributionid,E26KHUPDNH7E2X))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1102,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"distributionid\",\"E26KHUPDNH7E2X\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"distributionid\",\"E26KHUPDNH7E2X\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(distributionid,E26KHUPDNH7E2X)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(distributionid,E26KHUPDNH7E2X)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(\"hostedzoneid\",\"Z015965529V3Z8WL9WJMF\"))):splitby():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"761723964695\")),eq(hostedzoneid,Z015965529V3Z8WL9WJMF))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2204,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\", \"production-di-authentication-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,production-di-authentication-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2736,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(\"distributionid\",\"E3RBRZAVKOYKLZ\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(distributionid,E3RBRZAVKOYKLZ))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3230,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(\"distributionid\",\"E3RBRZAVKOYKLZ\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(\"distributionid\",\"E3RBRZAVKOYKLZ\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(distributionid,E3RBRZAVKOYKLZ)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(distributionid,E3RBRZAVKOYKLZ)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3762,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(\"hostedzoneid\",\"Z06269462RT1OC3QFCZZE\"))):splitby():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(or(eq(\"aws.account.id\",\"172348255554\")),eq(hostedzoneid,Z06269462RT1OC3QFCZZE))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\", \"058264132019\"), eq(\"hostedzoneid\", \"TODO\"))):splitBy():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\",\"058264132019\"),eq(hostedzoneid,TODO))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New API Gateway",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2204,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "resource"
+            ],
+            "metricSelector": "cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(\"apiname\", \"production-orchestration-oidc-api\"))):splitBy(\"resource\"):sum()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.apigateway.countByAccountIdApiNameMethodRegionResourceStage:filter(and(eq(apiname,production-orchestration-oidc-api))):splitBy(resource):sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Hosted Zone DNS Queries",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3762,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\", \"533266965190\"), eq(\"hostedzoneid\", \"TODO\"))):splitBy():sum",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.route53.dnsQueriesByAccountIdHostedZoneIdRegion:filter(and(eq(\"aws.account.id\",\"533266965190\"),eq(hostedzoneid,TODO))):splitBy():sum):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 608,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"058264132019\")),eq(\"distributionid\",\"E16QQ8G9BEL2NS\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"058264132019\")),eq(distributionid,E16QQ8G9BEL2NS))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1102,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"058264132019\")),eq(\"distributionid\",\"E16QQ8G9BEL2NS\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"058264132019\")),eq(\"distributionid\",\"E16QQ8G9BEL2NS\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"058264132019\")),eq(distributionid,E16QQ8G9BEL2NS)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"058264132019\")),eq(distributionid,E16QQ8G9BEL2NS)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Cloudfront Request Count",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 2736,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "metricSelector": "cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(\"distributionid\",\"E2SO8Y0KNJ1D62\"))):splitBy():sum:sort(value(sum,descending))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.requestsByAccountIdDistributionIdRegion:filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(distributionid,E2SO8Y0KNJ1D62))):splitBy():sum:sort(value(sum,descending))):limit(100):names"
+        ]
+      },
+      {
+        "name": "New Cloudfront Error Rate",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 3230,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(\"distributionid\",\"E2SO8Y0KNJ1D62\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          },
+          {
+            "id": "B",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "distributionid",
+              "dt.entity.cloud:aws:cloud_front:distribution",
+              "aws.region",
+              "aws.account.id",
+              "dt.source",
+              "dt.entity.cloud:aws:account",
+              "region",
+              "dt.entity.cloud:aws:region"
+            ],
+            "metricSelector": "cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(\"distributionid\",\"E2SO8Y0KNJ1D62\")))",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            },
+            {
+              "matcher": "B:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A",
+                  "B"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(distributionid,E2SO8Y0KNJ1D62)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(distributionid,E2SO8Y0KNJ1D62)))):limit(100):names"
+        ]
+      }
+    ]
+  }

--- a/dashboards/orchestration/cloudfront_migration_prod.json
+++ b/dashboards/orchestration/cloudfront_migration_prod.json
@@ -1,4 +1,4 @@
-  {
+{
     "metadata": {
       "configurationVersions": [
         7
@@ -56,8 +56,8 @@
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 2698,
-          "left": 0,
+          "top": 570,
+          "left": 1558,
           "width": 1520,
           "height": 38
         },
@@ -66,19 +66,6 @@
       },
       {
         "name": "Route 53",
-        "tileType": "HEADER",
-        "configured": true,
-        "bounds": {
-          "top": 1596,
-          "left": 0,
-          "width": 1520,
-          "height": 38
-        },
-        "tileFilter": {},
-        "isAutoRefreshDisabled": false
-      },
-      {
-        "name": "Production",
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
@@ -91,12 +78,12 @@
         "isAutoRefreshDisabled": false
       },
       {
-        "name": "API Gateway",
+        "name": "Production",
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 2166,
-          "left": 0,
+          "top": 0,
+          "left": 1558,
           "width": 1520,
           "height": 38
         },
@@ -104,12 +91,25 @@
         "isAutoRefreshDisabled": false
       },
       {
-        "name": "Route 53",
+        "name": "API Gateway",
         "tileType": "HEADER",
         "configured": true,
         "bounds": {
-          "top": 3724,
-          "left": 0,
+          "top": 38,
+          "left": 1558,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "OIDC WAF",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 1596,
+          "left": 1558,
           "width": 1520,
           "height": 38
         },
@@ -541,7 +541,7 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 1634,
+          "top": 2166,
           "left": 0,
           "width": 760,
           "height": 494
@@ -636,8 +636,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2204,
-          "left": 0,
+          "top": 76,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -733,8 +733,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2736,
-          "left": 0,
+          "top": 608,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -828,8 +828,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3230,
-          "left": 0,
+          "top": 1102,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -959,8 +959,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3762,
-          "left": 0,
+          "top": 2166,
+          "left": 1558,
           "width": 760,
           "height": 494
         },
@@ -1054,7 +1054,7 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 1634,
+          "top": 2166,
           "left": 760,
           "width": 760,
           "height": 494
@@ -1149,8 +1149,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2204,
-          "left": 760,
+          "top": 76,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -1246,8 +1246,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3762,
-          "left": 760,
+          "top": 2166,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -1567,8 +1567,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 2736,
-          "left": 760,
+          "top": 608,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -1662,8 +1662,8 @@
         "tileType": "DATA_EXPLORER",
         "configured": true,
         "bounds": {
-          "top": 3230,
-          "left": 760,
+          "top": 1102,
+          "left": 2318,
           "width": 760,
           "height": 494
         },
@@ -1786,6 +1786,420 @@
         },
         "metricExpressions": [
           "resolution=null&(cloud.aws.cloudfront.\"4xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(distributionid,E2SO8Y0KNJ1D62)))):limit(100):names,(cloud.aws.cloudfront.\"5xxErrorRateByAccountIdDistributionIdRegion\":filter(and(or(eq(\"aws.account.id\",\"533266965190\")),eq(distributionid,E2SO8Y0KNJ1D62)))):limit(100):names"
+        ]
+      },
+      {
+        "name": "Old OIDC WAF Blocked Request Count by Rule",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 1558,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"172348255554\"), contains(\"webacl\", \"OIDC\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"172348255554\"),contains(webacl,OIDC))):splitBy(labelname):count):limit(100):names"
+        ]
+      },
+      {
+        "name": "New OIDC WAF Blocked Request Count by Rule",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 2318,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"533266965190\"), contains(\"webacl\", \"OIDC\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"533266965190\"),contains(webacl,OIDC))):splitBy(labelname):count):limit(100):names"
+        ]
+      },
+      {
+        "name": "Route 53",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 2128,
+          "left": 1558,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "OIDC WAF",
+        "tileType": "HEADER",
+        "configured": true,
+        "bounds": {
+          "top": 1596,
+          "left": 0,
+          "width": 1520,
+          "height": 38
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false
+      },
+      {
+        "name": "Old OIDC WAF Blocked Request Count by Rule",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 0,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"761723964695\"), contains(\"webacl\", \"OIDC-Integration\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"761723964695\"),contains(webacl,OIDC-Integration))):splitBy(labelname):count):limit(100):names"
+        ]
+      },
+      {
+        "name": "New OIDC WAF Blocked Request Count by Rule",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 1634,
+          "left": 760,
+          "width": 760,
+          "height": 494
+        },
+        "tileFilter": {},
+        "isAutoRefreshDisabled": false,
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "spaceAggregation": "AUTO",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "labelname"
+            ],
+            "metricSelector": "cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\", \"058264132019\"), contains(\"webacl\", \"OIDC-Integration\"))):splitBy(\"labelname\"):count()",
+            "rate": "NONE",
+            "enabled": true,
+            "histogram": false
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {},
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {
+            "yAxis": "VALUE"
+          },
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "hiddenColumns": []
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          },
+          "honeycombSettings": {
+            "showHive": true,
+            "showLegend": true,
+            "showLabels": false
+          }
+        },
+        "queriesSettings": {
+          "resolution": ""
+        },
+        "metricExpressions": [
+          "resolution=null&(cloud.aws.wafv2.blockRuleMatchByAccountIdLabelNameLabelNamespaceRegionWebACL:filter(and(eq(\"aws.account.id\",\"058264132019\"),contains(webacl,OIDC-Integration))):splitBy(labelname):count):limit(100):names"
         ]
       }
     ]

--- a/dashboards/orchestration/cloudfront_migration_prod.json
+++ b/dashboards/orchestration/cloudfront_migration_prod.json
@@ -5,7 +5,6 @@
       ],
       "clusterVersion": "1.341.59.20260630-211352"
     },
-    "id": "a34783ee-a7f1-4a3e-bd19-099ff989e133",
     "dashboardMetadata": {
       "name": "orchestration-cloudfront-migration-monitoring",
       "shared": true,


### PR DESCRIPTION
# Description:
- Adds rough dashboards for the Orchestration API Gateway and Cloudfront migration
- Note that for some tiles, the placeholder "TODO" is used for IDs for resources yet to be provisioned

## Ticket number:
[ATO-2704](https://govukverify.atlassian.net/browse/ATO-2704)

## Checklist:
- [x] Is my change backwards compatible? Please include evidence
- [x] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[ATO-2704]: https://govukverify.atlassian.net/browse/ATO-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ