### PR TITLE
OJ-3767: Add OAuthCommon tiles to check-hmrc lambda dashboard

### DIFF
--- a/dashboards/orange/check-hmrc-lambda-metrics.json
+++ b/dashboards/orange/check-hmrc-lambda-metrics.json
@@ -34,7 +34,7 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 266,
+        "top": 532,
         "left": 1178,
         "width": 1140,
         "height": 38
@@ -48,7 +48,7 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 532,
+        "top": 1064,
         "left": 1178,
         "width": 1140,
         "height": 38
@@ -76,7 +76,7 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 1368,
+        "top": 1672,
         "left": 0,
         "width": 1140,
         "height": 38
@@ -119,11 +119,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "check-hmrc-cri-api-private",
+                    "value": "check-hmrc-cri-api-public",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "check-hmrc-cri-api-public",
+                    "value": "check-hmrc-cri-api-private",
                     "evaluator": "EQ"
                   }
                 ]
@@ -133,7 +133,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -239,11 +240,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "check-hmrc-cri-api-private",
+                    "value": "check-hmrc-cri-api-public",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "check-hmrc-cri-api-public",
+                    "value": "check-hmrc-cri-api-private",
                     "evaluator": "EQ"
                   }
                 ]
@@ -253,7 +254,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -340,7 +342,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1406,
+        "top": 1710,
         "left": 380,
         "width": 760,
         "height": 304
@@ -369,11 +371,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "check-hmrc-cri-api-private",
+                    "value": "check-hmrc-cri-api-public",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "check-hmrc-cri-api-public",
+                    "value": "check-hmrc-cri-api-private",
                     "evaluator": "EQ"
                   }
                 ]
@@ -383,7 +385,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -470,7 +473,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1406,
+        "top": 1710,
         "left": 0,
         "width": 380,
         "height": 304
@@ -513,7 +516,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -590,7 +594,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1862,
+        "top": 2166,
         "left": 0,
         "width": 380,
         "height": 152
@@ -629,7 +633,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -709,7 +714,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1710,
+        "top": 2014,
         "left": 0,
         "width": 380,
         "height": 152
@@ -748,7 +753,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -780,7 +786,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": false
+          "enabled": false,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -871,7 +878,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1710,
+        "top": 2014,
         "left": 380,
         "width": 760,
         "height": 304
@@ -889,7 +896,8 @@
           ],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -900,7 +908,8 @@
           ],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):splitBy(\"dt.entity.aws_lambda_function\"):avg:sort(value(avg,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -911,7 +920,8 @@
           ],
           "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):splitBy(\"dt.entity.aws_lambda_function\"):sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1041,7 +1051,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-AbandonFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1050,7 +1061,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-AbandonFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1166,7 +1178,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-AbandonFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1175,7 +1188,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-AbandonFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1291,7 +1305,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-AbandonFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1300,7 +1315,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-AbandonFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "D",
@@ -1309,7 +1325,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-AbandonFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1453,7 +1470,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-NinoCheckFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1462,7 +1480,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-NinoCheckFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1578,7 +1597,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-NinoCheckFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1587,7 +1607,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-NinoCheckFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1703,7 +1724,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-NinoCheckFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1712,7 +1734,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-NinoCheckFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "D",
@@ -1721,7 +1744,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-NinoCheckFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1856,18 +1880,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "http",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "MatchingHandler",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -1882,13 +1894,26 @@
                     "evaluator": "EQ"
                   }
                 ]
+              },
+              {
+                "filter": "http",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "MatchingHandler",
+                    "evaluator": "EQ"
+                  }
+                ]
               }
             ],
             "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1902,6 +1927,18 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
+                "filter": "http",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "MatchingHandler",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -1916,25 +1953,14 @@
                     "evaluator": "EQ"
                   }
                 ]
-              },
-              {
-                "filter": "http",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "MatchingHandler",
-                    "evaluator": "EQ"
-                  }
-                ]
               }
             ],
             "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -1966,11 +1992,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "value": "di-ipv-cri-check-hmrc-api-Matching",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-Matching",
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
                     "evaluator": "EQ"
                   }
                 ]
@@ -1980,7 +2006,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2085,7 +2112,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(service,di-ipv-cri-check-hmrc-api-Matching),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)),or(eq(http,MatchingHandler)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(service,di-ipv-cri-check-hmrc-api-Matching),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)),or(eq(http,MatchingHandler)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(service,di-ipv-cri-check-hmrc-api-Matching),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)),or(eq(http,MatchingHandler)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,MatchingHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-Matching)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,MatchingHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-Matching)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,MatchingHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-Matching)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -2114,6 +2141,22 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
+                "filter": "service",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-OTG",
+                    "evaluator": "EQ"
+                  },
+                  {
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "evaluator": "EQ"
+                  }
+                ]
+              },
+              {
                 "filter": "http",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -2124,29 +2167,14 @@
                     "evaluator": "EQ"
                   }
                 ]
-              },
-              {
-                "filter": "service",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
-                    "evaluator": "EQ"
-                  },
-                  {
-                    "value": "di-ipv-cri-check-hmrc-api-OTG",
-                    "evaluator": "EQ"
-                  }
-                ]
               }
             ],
             "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2160,18 +2188,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "http",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "OTGHandler",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -2186,13 +2202,26 @@
                     "evaluator": "EQ"
                   }
                 ]
+              },
+              {
+                "filter": "http",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "OTGHandler",
+                    "evaluator": "EQ"
+                  }
+                ]
               }
             ],
             "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -2212,11 +2241,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-OTG",
+                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "di-ipv-cri-check-hmrc-api-NinoCheckFunction",
+                    "value": "di-ipv-cri-check-hmrc-api-OTG",
                     "evaluator": "EQ"
                   }
                 ]
@@ -2238,7 +2267,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2343,7 +2373,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-OTG),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-OTG),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-OTG),eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-check-hmrc-api.responseLatencyByAccountIdHTTPRegionservice:filter(and(or(eq(http,OTGHandler)),or(eq(service,di-ipv-cri-check-hmrc-api-NinoCheckFunction),eq(service,di-ipv-cri-check-hmrc-api-OTG)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -2351,8 +2381,8 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1064,
-        "left": 1140,
+        "top": 1368,
+        "left": 0,
         "width": 304,
         "height": 304
       },
@@ -2375,7 +2405,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2446,8 +2477,8 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 1064,
-        "left": 1444,
+        "top": 1368,
+        "left": 304,
         "width": 304,
         "height": 304
       },
@@ -2469,7 +2500,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2570,7 +2602,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-IssueCredentialFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2579,7 +2612,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-IssueCredentialFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2695,7 +2729,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-IssueCredentialFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2704,7 +2739,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-IssueCredentialFunction~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2820,7 +2856,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-IssueCredentialFunction~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2829,7 +2866,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-IssueCredentialFunction~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "D",
@@ -2838,7 +2876,8 @@
           "splitBy": [],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-IssueCredentialFunction~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2991,7 +3030,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3023,7 +3063,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3162,7 +3203,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3194,7 +3236,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3333,7 +3376,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3365,7 +3409,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -3397,7 +3442,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3511,7 +3557,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 304,
+        "top": 570,
         "left": 1178,
         "width": 380,
         "height": 228
@@ -3550,7 +3596,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3582,7 +3629,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3682,7 +3730,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 304,
+        "top": 570,
         "left": 1558,
         "width": 380,
         "height": 228
@@ -3721,7 +3769,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3753,7 +3802,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3853,7 +3903,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 304,
+        "top": 570,
         "left": 1938,
         "width": 380,
         "height": 228
@@ -3892,7 +3942,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3924,7 +3975,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -3956,7 +4008,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4070,7 +4123,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 570,
+        "top": 1102,
         "left": 1178,
         "width": 380,
         "height": 228
@@ -4109,7 +4162,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4141,7 +4195,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4241,7 +4296,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 570,
+        "top": 1102,
         "left": 1558,
         "width": 380,
         "height": 228
@@ -4280,7 +4335,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4312,7 +4368,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4412,7 +4469,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 570,
+        "top": 1102,
         "left": 1938,
         "width": 380,
         "height": 228
@@ -4451,7 +4508,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4483,7 +4541,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -4515,7 +4574,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4622,6 +4682,1259 @@
       },
       "metricExpressions": [
         "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"common-cri-api-AccessTokenFunctionTS~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"common-cri-api-AccessTokenFunctionTS~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.equals(~\"common-cri-api-AccessTokenFunctionTS~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 266,
+        "left": 1178,
+        "width": 1140,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## OAuthCommon Session Function"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 798,
+        "left": 1178,
+        "width": 1140,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## OAuthCommon Authorization Function"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1330,
+        "left": 1178,
+        "width": 1140,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## OAuthCommon Access Token"
+    },
+    {
+      "name": "Invocations and Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 1178,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Errors"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "A:",
+            "properties": {
+              "color": "DEFAULT"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Concurrent Executions",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 1558,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Concurrent Executions"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Throttles"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Duration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 1938,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Invocations and Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 1178,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Invocations"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Concurrent Executions",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 1558,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Concurrent Executions"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Throttles"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Duration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 1938,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": false
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Invocations and Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1368,
+        "left": 1178,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Invocations"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Concurrent Executions",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1368,
+        "left": 1558,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Concurrent Executions"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Throttles"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Duration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1368,
+        "left": 1938,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"check-hmrc-cri-api-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Add `OAuthCommon` tiles to `check-hmrc` lambda dashboard.

Cloned dashboard - https://khw46367.apps.dynatrace.com/ui/apps/dynatrace.classic.dashboards/#dashboard;gtf=-7d%20to%20now;gf=8862942234149009984;id=6d8feda5-8828-4037-9f0b-5e774c248bed

Part screenshot;
<img width="1143" height="755" alt="image" src="https://github.com/user-attachments/assets/84109d50-ecea-4cb3-9a4b-3af6af2ed37a" />

## Ticket number:
[OJ-3767]

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:


[OJ-3767]: https://govukverify.atlassian.net/browse/OJ-3767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ