### PR TITLE
AUT-5545: Add 'preset = true' to Passkeys dashboard

### DIFF
--- a/dashboards/authentication/di-auth-passkeys/main.tf
+++ b/dashboards/authentication/di-auth-passkeys/main.tf
@@ -17,6 +17,7 @@ resource "dynatrace_dashboard_sharing" "main" {
   dashboard_id = dynatrace_json_dashboard.main.id
 
   enabled = true
+  preset  = true
 
   permissions {
     permission {

--- a/dashboards/authentication/di-auth-passkeys/variables.tf
+++ b/dashboards/authentication/di-auth-passkeys/variables.tf
@@ -1,9 +1,9 @@
 variable "application_environment" {
-  type = string
+  type        = string
   description = "Environment of the application"
 }
 
 variable "account_id" {
-  type = string
+  type        = string
   description = "AWS Account ID"
 }


### PR DESCRIPTION
# Description:

- Add 'preset = true' to Passkeys dashboard
- Terraform formatting applied

Without this flag the dashboard is not visible in Dynatrace

## Ticket number:
AUT-5545

## Checklist:
- [ ] Is my change backwards compatible? Please include evidence
- [ ] I have tested this and added output to Jira Comment:
- [ ] Documentation added (link) Comment:
