### PR TITLE
OJ-3824: Add OAuthCommon tiles to Experian KBV lambda dashboard

### DIFF
--- a/dashboards/orange/experian-kbv-lambda-metrics.json
+++ b/dashboards/orange/experian-kbv-lambda-metrics.json
@@ -20,7 +20,7 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 532,
+        "top": 1064,
         "left": 2432,
         "width": 1140,
         "height": 38
@@ -76,7 +76,7 @@
       "tileType": "MARKDOWN",
       "configured": true,
       "bounds": {
-        "top": 266,
+        "top": 532,
         "left": 2432,
         "width": 1140,
         "height": 38
@@ -104,7 +104,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 570,
+        "top": 1102,
         "left": 2432,
         "width": 380,
         "height": 228
@@ -143,7 +143,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -175,7 +176,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -275,7 +277,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 570,
+        "top": 1102,
         "left": 2812,
         "width": 380,
         "height": 228
@@ -314,7 +316,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -346,7 +349,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -446,7 +450,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 570,
+        "top": 1102,
         "left": 3192,
         "width": 380,
         "height": 228
@@ -485,7 +489,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -517,7 +522,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -549,7 +555,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -702,7 +709,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -734,7 +742,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -873,7 +882,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -905,7 +915,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1044,7 +1055,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1076,7 +1088,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -1108,7 +1121,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1222,7 +1236,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 304,
+        "top": 570,
         "left": 2432,
         "width": 380,
         "height": 228
@@ -1261,7 +1275,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1293,7 +1308,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1393,7 +1409,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 304,
+        "top": 570,
         "left": 2812,
         "width": 380,
         "height": 228
@@ -1432,7 +1448,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1464,7 +1481,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1564,7 +1582,7 @@
       "tileType": "DATA_EXPLORER",
       "configured": true,
       "bounds": {
-        "top": 304,
+        "top": 570,
         "left": 3192,
         "width": 380,
         "height": 228
@@ -1603,7 +1621,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1635,7 +1654,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "D",
@@ -1667,7 +1687,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -1848,7 +1869,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -1880,7 +1902,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2019,7 +2042,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2051,7 +2075,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2190,7 +2215,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2222,7 +2248,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -2254,7 +2281,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2407,7 +2435,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2439,7 +2468,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2578,7 +2608,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2610,7 +2641,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2749,7 +2781,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2781,7 +2814,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -2813,7 +2847,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -2966,7 +3001,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -2998,7 +3034,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3137,7 +3174,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3169,7 +3207,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3308,7 +3347,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -3340,7 +3380,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -3372,7 +3413,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3515,11 +3557,11 @@
                 "nestedFilters": [],
                 "criteria": [
                   {
-                    "value": "kbv-cri-kbv-cri-api-v1",
+                    "value": "kbv-cri-private-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   },
                   {
-                    "value": "kbv-cri-private-kbv-cri-api-v1",
+                    "value": "kbv-cri-kbv-cri-api-v1",
                     "evaluator": "EQ"
                   }
                 ]
@@ -3529,7 +3571,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3649,7 +3692,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3779,7 +3823,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -3899,7 +3944,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4025,7 +4071,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4057,7 +4104,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": false
+          "enabled": false,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4186,7 +4234,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4319,7 +4368,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4351,7 +4401,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4490,7 +4541,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4522,7 +4574,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4661,7 +4714,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4693,7 +4747,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -4725,7 +4780,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -4858,7 +4914,8 @@
           ],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -4869,7 +4926,8 @@
           ],
           "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):avg:sort(value(avg,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -4880,7 +4938,8 @@
           ],
           "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1~\")\"))))):splitBy(\"dt.entity.aws_lambda_function\"):sum:sort(value(sum,descending)):limit(20)",
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -5001,18 +5060,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "service",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "di-ipv-cri-kbv-api-question",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "aws.region",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5023,13 +5070,26 @@
                     "evaluator": "EQ"
                   }
                 ]
+              },
+              {
+                "filter": "service",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "di-ipv-cri-kbv-api-question",
+                    "evaluator": "EQ"
+                  }
+                ]
               }
             ],
             "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -5071,7 +5131,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -5113,7 +5174,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -5211,7 +5273,7 @@
         "resolution": ""
       },
       "metricExpressions": [
-        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.get_questions_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)),or(eq(service,di-ipv-cri-kbv-api-question)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_questions_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)),or(eq(service,di-ipv-cri-kbv-api-question)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_questions_durationByAccountIdRegionService:filter(and(or(eq(\"aws.region\",eu-west-2)),or(eq(service,di-ipv-cri-kbv-api-question)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names"
+        "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.get_questions_durationByAccountIdRegionService:filter(and(or(eq(service,di-ipv-cri-kbv-api-question)),or(eq(\"aws.region\",eu-west-2)))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_questions_durationByAccountIdRegionService:filter(and(or(eq(service,di-ipv-cri-kbv-api-question)),or(eq(\"aws.region\",eu-west-2)))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names,(cloud.aws.di-ipv-cri-kbv-api.get_questions_durationByAccountIdRegionService:filter(and(or(eq(service,di-ipv-cri-kbv-api-question)),or(eq(\"aws.region\",eu-west-2)))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names"
       ]
     },
     {
@@ -5268,7 +5330,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -5310,7 +5373,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -5324,18 +5388,6 @@
             "filterOperator": "AND",
             "nestedFilters": [
               {
-                "filter": "aws.region",
-                "filterType": "DIMENSION",
-                "filterOperator": "OR",
-                "nestedFilters": [],
-                "criteria": [
-                  {
-                    "value": "eu-west-2",
-                    "evaluator": "EQ"
-                  }
-                ]
-              },
-              {
                 "filter": "service",
                 "filterType": "DIMENSION",
                 "filterOperator": "OR",
@@ -5346,13 +5398,26 @@
                     "evaluator": "EQ"
                   }
                 ]
+              },
+              {
+                "filter": "aws.region",
+                "filterType": "DIMENSION",
+                "filterOperator": "OR",
+                "nestedFilters": [],
+                "criteria": [
+                  {
+                    "value": "eu-west-2",
+                    "evaluator": "EQ"
+                  }
+                ]
               }
             ],
             "criteria": []
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -5495,7 +5560,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "B",
@@ -5525,7 +5591,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         },
         {
           "id": "C",
@@ -5555,7 +5622,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -5684,7 +5752,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -5778,7 +5847,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -5872,7 +5942,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -5983,7 +6054,8 @@
           },
           "limit": 20,
           "rate": "NONE",
-          "enabled": true
+          "enabled": true,
+          "histogram": false
         }
       ],
       "visualConfig": {
@@ -6064,6 +6136,1263 @@
       },
       "metricExpressions": [
         "resolution=null&(cloud.aws.di-ipv-cri-kbv-api.initial_questions_response_timeoutByAccountIdRegionService:splitBy():count:sort(value(avg,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 266,
+        "left": 2432,
+        "width": 1140,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## OAuthCommon Session Function"
+    },
+    {
+      "name": "Invocations and Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 2432,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Invocations"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Concurrent Executions",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 2812,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Concurrent Executions"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Throttles"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Duration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 304,
+        "left": 3192,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-SessionFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 798,
+        "left": 2432,
+        "width": 1140,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## OAuthCommon Access Token Function"
+    },
+    {
+      "name": "Invocations and Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 2432,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Invocations"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Concurrent Executions",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 2812,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Concurrent Executions"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Throttles"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Duration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 836,
+        "left": 3192,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "D",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximun"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "D:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "D"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AccessTokenFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 1330,
+        "left": 2432,
+        "width": 1140,
+        "height": 38
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "markdown": "## OAuthCommon Authorization Function"
+    },
+    {
+      "name": "Invocations and Errors",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1368,
+        "left": 2432,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Invocations"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Errors"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.invocations:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.errors:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Concurrent Executions",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1368,
+        "left": 2812,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Concurrent Executions"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Throttles"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.concExecutions:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.throttlers:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():sort(value(auto,descending)):limit(20)):limit(100):names"
+      ]
+    },
+    {
+      "name": "Duration",
+      "tileType": "DATA_EXPLORER",
+      "configured": true,
+      "bounds": {
+        "top": 1368,
+        "left": 3192,
+        "width": 380,
+        "height": 228
+      },
+      "tileFilter": {},
+      "isAutoRefreshDisabled": false,
+      "customName": "Data explorer results",
+      "queries": [
+        {
+          "id": "A",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "B",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        },
+        {
+          "id": "C",
+          "spaceAggregation": "AUTO",
+          "timeAggregation": "DEFAULT",
+          "splitBy": [],
+          "metricSelector": "builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)",
+          "rate": "NONE",
+          "enabled": true,
+          "histogram": false
+        }
+      ],
+      "visualConfig": {
+        "type": "GRAPH_CHART",
+        "global": {},
+        "rules": [
+          {
+            "matcher": "A:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "RED",
+              "seriesType": "LINE",
+              "alias": "Maximum"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "B:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "YELLOW",
+              "seriesType": "LINE",
+              "alias": "Average"
+            },
+            "seriesOverrides": []
+          },
+          {
+            "matcher": "C:",
+            "unitTransform": "auto",
+            "valueFormat": "auto",
+            "properties": {
+              "color": "GREEN",
+              "seriesType": "LINE",
+              "alias": "Minimum"
+            },
+            "seriesOverrides": []
+          }
+        ],
+        "axes": {
+          "xAxis": {
+            "displayName": "",
+            "visible": true
+          },
+          "yAxes": [
+            {
+              "displayName": "",
+              "visible": true,
+              "min": "AUTO",
+              "max": "AUTO",
+              "position": "LEFT",
+              "queryIds": [
+                "A",
+                "B",
+                "C"
+              ],
+              "defaultAxis": true
+            }
+          ]
+        },
+        "heatmapSettings": {
+          "yAxis": "VALUE",
+          "showLabels": false
+        },
+        "singleValueSettings": {
+          "showTrend": true,
+          "showSparkLine": true,
+          "linkTileColorToThreshold": true
+        },
+        "thresholds": [
+          {
+            "axisTarget": "LEFT",
+            "columnId": "LambdaFunction code execution time.",
+            "rules": [
+              {
+                "color": "#7dc540"
+              },
+              {
+                "color": "#f5d30f"
+              },
+              {
+                "color": "#dc172a"
+              }
+            ],
+            "queryId": "A",
+            "visible": true
+          }
+        ],
+        "tableSettings": {
+          "hiddenColumns": []
+        },
+        "graphChartSettings": {
+          "connectNulls": true
+        },
+        "honeycombSettings": {
+          "showHive": true,
+          "showLegend": true,
+          "showLabels": false
+        }
+      },
+      "queriesSettings": {
+        "resolution": ""
+      },
+      "metricExpressions": [
+        "resolution=null&(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():max:sort(value(max,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():avg:sort(value(avg,descending)):limit(20)):limit(100):names,(builtin:cloud.aws.lambda.duration:filter(and(or(in(\"dt.entity.aws_lambda_function\",entitySelector(\"type(aws_lambda_function),entityName.contains(~\"kbv-cri-api-v1-OAuth-~\"),entityName.contains(~\"-AuthorizationFn~\")\"))))):splitBy():min:sort(value(min,descending)):limit(20)):limit(100):names"
       ]
     }
   ]


### PR DESCRIPTION
# Description:

Add OAuthCommon tiles to Experian KBV lambda dashboard

## Ticket number:
[OJ-3824]

## Screenshot:
<img width="1240" height="593" alt="image" src="https://github.com/user-attachments/assets/1672935a-24e1-4e6d-aa05-31ae3e10f1f4" />



[OJ-3824]: https://govukverify.atlassian.net/browse/OJ-3824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ